### PR TITLE
Clarify README, Fix Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ COPY . /music-box/
 RUN pip3 install requests
 
 # nodejs modules needed Mechanism-To-Code
-RUN npm install express helmet
+RUN cd /music-box/libs/MechanismToCode; \
+    npm install
 
 # install json-fortran
 RUN curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.1.0.tar.gz \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To set up the box model with the Chapman chemistry mechanism from the [Public Ch
 ```
 docker build -t music-box-test . --build-arg TAG_ID=chapman
 docker run -it music-box-test bash
-cd music-box/build
+cd build
 ```
 
 From here, you can specify model parameters and initial conditions, or use one of the test configurations provided in `/examples`, such as:

--- a/README.md
+++ b/README.md
@@ -13,35 +13,35 @@ Copyright (C) 2020 National Center for Atmospheric Research
 The fastest way to get started with MusicBox is with Docker. You will need to have [Docker Desktop](https://www.docker.com/get-started) and [git](https://git-scm.com) installed. Then, from a terminal window run:
 
 ```
-git clone https://github.com/NCAR/MusicBox2
-cd MusicBox2
+git clone --recurse-submodules https://github.com/NCAR/music-box
+cd music-box
 ```
 
-To set up the box model with mechanism 272 (Chapman chemistry) from the [Chemistry Cafe](https://chemistrycafe-devel.acom.ucar.edu/index.html#/Tags), run:
+To set up the box model with the Chapman chemistry mechanism from the [Public Chemistry Cafe Mechanism Store](https://www.acom.ucar.edu/cafe), run:
 
 ```
-docker build -t music-box-test . --build-arg TAG_ID=272
+docker build -t music-box-test . --build-arg TAG_ID=chapman
 docker run -it music-box-test bash
-cd build
+cd music-box/build
 ```
 
 From here, you can specify model parameters and initial conditions, or use one of the test configurations provided in `/examples`, such as:
 
 ```
-./musicbox ../MusicBox2/examples/dark_chamber/config.json
+./music_box ../music-box/examples/dark_chamber/config.json
 ```
 
 The results will be in a file named `output.csv`.
 
 # Documentation
 
-MusicBox documentation can be built using [Doxygen](doxygen.nl). After installing Doxygen, from the root MusicBox folder run:
+MusicBox documentation can be built using [Doxygen](https://www.doxygen.nl). After [installing](https://www.doxygen.nl/download.html) Doxygen, from the root MusicBox folder run:
 
 ```
 cd doc
 doxygen
 ```
-Then, open `MusicBox/doc/build/html/index.html` in a browser.
+Then, open `music-box/doc/html/index.html` in a browser.
 
 The documentation includes more detailed instructions for configuring the model, along with developer resources.
 


### PR DESCRIPTION
README previously referred to MusicBox2.  
Dockerfile can use the package.json to install verified dependent packages.