### PR TITLE
add submodule status script

### DIFF
--- a/tell_me_about_the_submodules.sh
+++ b/tell_me_about_the_submodules.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+this_dir=$(pwd)
+printf "\nSubmodule status\n"
+printf "(currently checked out commit for each submodule)\n"
+printf "(when the submodule is initialized and a tag exists, the commit is shown as: 'most recent tag-commits since tag-commit hash')\n"
+printf "(when the submodule is not initialized, only the checked out commit is shown)\n\n"
+grep path .gitmodules | sed 's/.*= //' | while read x
+do
+  cd "$this_dir"
+  printf "$x\n   - current commit: "
+  if [ "$(ls -A $x)" ] ; then
+    cd "$x"
+    git describe --tags --always
+  else
+    git submodule status $x | sed 's/^-//' | awk '{ print $1 }'
+  fi
+done
+printf "\n"


### PR DESCRIPTION
The `tell_me_about_the_submodules.sh` script in the root folder should show what commit each submodule is associated with. If there is a tag in the submodule history it will show the most recent tag and how many commits ahead of the tag the submodule points to. It should also work if the submodules are not initialized, but only the commit for each submodule is shown (not the tag info). If this is useful we can copy it into any repo with submodules