### PR TITLE
remove interactive submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "libs/micm"]
 	path = libs/micm
 	url = https://github.com/NCAR/micm.git
-[submodule "libs/music-box-interactive"]
-  path = libs/music-box-interactive
-  url = https://github.com/NCAR/music-box-interactive.git
 [submodule "libs/camp"]
 	path = libs/camp
 	url = https://github.com/open-atmos/camp.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:37
 
 RUN dnf -y update \
     && dnf -y install \
@@ -95,7 +95,7 @@ RUN cd /build \
       && make
 
 # Prepare the music-box-interactive web server
-RUN mv music-box/libs/music-box-interactive .
+RUN git clone https://github.com/NCAR/music-box-interactive.git --branch music-box-main --single-branch
 ENV MUSIC_BOX_BUILD_DIR=/build
 
 EXPOSE 8000


### PR DESCRIPTION
Removes https://github.com/NCAR/music-box-interactive as a submodule. Updates `Dockerfile` to clone interactive for local builds.