### PR TITLE
Setting up a project script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ dependencies = [
 
 [project.urls]
 Home = "https://github.com/NCAR/music-box"
+
+[project.scripts]
+music_box = "acom_music_box:main"

--- a/src/acom_music_box/__init__.py
+++ b/src/acom_music_box/__init__.py
@@ -20,4 +20,4 @@ from .music_box_conditions import Conditions
 from .music_box_evolving_conditions import EvolvingConditions
 from acom_music_box import music_box_logger
 from .music_box import MusicBox
-
+from .acom_music_box import main

--- a/src/acom_music_box/acom_music_box.py
+++ b/src/acom_music_box/acom_music_box.py
@@ -29,7 +29,7 @@ def getArgsDictionary(argPairs):
 
 
 
-if __name__ == "__main__":
+def main():
     music_box_logger.progress("{}".format(__file__))
     music_box_logger.progress("Start time: {}".format(datetime.datetime.now()))
     
@@ -56,3 +56,6 @@ if __name__ == "__main__":
 
     music_box_logger.progress("End time: {}".format(datetime.datetime.now()))
     sys.exit(0)
+
+if __name__ == "__main__":
+   main()


### PR DESCRIPTION
To get the script to work with

```
[project.scripts]
music_box = "acom_music_box:main"
```

We need to be able to run something like `from acom_music_box import main; main()`

To achieve that, I had to rename `music_box_main.py` to `acom_music_box.py` and put everything inside the `if __name__ == '__main__':` block into a function called main