### PR TITLE
Adding python script to extract data from WACCM for input to MusicBox

### DIFF
--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -228,8 +228,8 @@ def writeInitJSON(initValues, filename):
 def insertIntoTemplate(initValues, templateDir, destDir):
 
   # copy the template directory to working area
-  destPath = os.path.basename(os.path.normpath(templateDir))
-  destPath = os.path.join(destDir, destPath)
+  destZip = os.path.basename(os.path.normpath(templateDir))
+  destPath = os.path.join(destDir, destZip)
   logger.info("Create new configuration in = {}".format(destPath))
 
   # remove directory if it already exists
@@ -274,8 +274,14 @@ def insertIntoTemplate(initValues, templateDir, destDir):
   envConfig["pressure"]["initial value [Pa]"] = pressure
 
   # save over the former json file
-  with open(myConfigFile, "w") as myConfigFile:
-    json.dump(myConfig, myConfigFile, indent=2)
+  with open(myConfigFile, "w") as myConfigFp:
+    json.dump(myConfig, myConfigFp, indent=2)
+
+  # compress the written directory as a zip file
+  shutil.make_archive(destPath, "zip",
+    root_dir=destDir, base_dir=destZip)
+
+  # move into the created directory
 
   return
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -76,12 +76,12 @@ def safeFloat(numString):
 def getMusicaDictionary():
    varMap = {
       "H2O": "H2O",
-      "TEPOMUC": "jtepo",
+      "TEPOMUC": "jtepo",   # test var not in WACCM
       "BENZENE": "jbenzene",
       "O3": "O3",
       "NH3": "NH3",
       "CH4": "CH4",
-      "O": "O"          # test var not in WACCM
+      "O": "O"             # test var not in WACCM
    }
 
    return(dict(sorted(varMap.items())))
@@ -142,6 +142,21 @@ def readWACCM(waccmMusicaDict, latitude, longitude,
 
 
 
+# Perform any numeric conversion needed.
+# varDict = originally read from WACCM, tuples are (musicaName, value, units)
+# return varDict with values modified
+def convertWaccm(varDict):
+   # set up indexes for the tuple
+   musicaIndex = 0
+   valueIndex = 1
+   unitIndex = 2
+
+   nh3Tuple = varDict["NH3"]
+   varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[2])
+   return(varDict)
+
+
+
 # Main routine begins here.
 def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -188,9 +203,11 @@ def main():
     # Read named variables from WACCM model output.
     varValues = readWACCM(getMusicaDictionary(),
       lat, lon, retrieveWhen, waccmDir)
-    logger.info("WACCM varValues = {}".format(varValues))
+    logger.info("Original WACCM varValues = {}".format(varValues))
 
     # Perform any conversions needed, or derive variables.
+    convertWaccm(varValues)
+    logger.info("Converted WACCM varValues = {}".format(varValues))
 
     # Write CSV file for MusicBox initial conditions.
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# waccmToMusicBox.py
+# MusicBox: Extract variables from WACCM model output,
+# and convert to initial conditions for MusicBox (case TS1).
+#
+# Author: Carl Drews
+# Copyright 2024 by Atomospheric Chemistry Observations & Modeling (UCAR/ACOM)
+
+#import os
+import argparse
+#import numpy
+import datetime
+import xarray
+import sys
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+
+# configure argparse for key-value pairs
+class KeyValueAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        for value in values:
+            key, val = value.split('=')
+            setattr(namespace, key, val)
+
+# Retrieve named arguments from the command line and
+# return in a dictionary of keywords.
+# argPairs = list of arguments, probably from sys.argv[1:]
+#       named arguments are formatted like this=3.14159
+# return dictionary of keywords and values
+def getArgsDictionary(argPairs):
+    parser = argparse.ArgumentParser(
+        description='Process some key=value pairs.')
+    parser.add_argument(
+        'key_value_pairs',
+        nargs='+',  # This means one or more arguments are expected
+        action=KeyValueAction,
+        help="Arguments in key=value format. Example: configFile=my_config.json"
+    )
+
+    argDict = vars(parser.parse_args(argPairs))      # return dictionary
+
+    return (argDict)
+
+
+
+# Convert safely from string to integer (alphas convert to 0).
+def safeInt(intString):
+        intValue = 0
+        try:
+                intValue = int(intString)
+        except ValueError as error:
+                intValue = 0
+
+        return intValue
+
+
+
+# Convert string to number, or 0.0 if not numeric.
+# numString = string that probably can be converted
+def safeFloat(numString):
+	result = -1.0
+	try:
+		result = float(numString)
+	except ValueError:
+		result = 0.0
+
+	return result
+
+
+
+# Build and return dictionary of WACCM variable names
+# and their MusicBox equivalents.
+def getMusicaDictionary():
+   varMap = {
+      "Nairobi": [-1.2921, 36.8219],
+      "Kampala": [0.3476, 32.5825],
+      "Kigali": [-1.9441, 30.0619],
+      "Dodoma": [-6.1630, 35.7516],
+      "Lilongwe": [-13.9626, 33.7741],
+      "Lusaka": [-15.3875, 28.3228]
+   }
+
+   return(dict(sorted(varMap.items())))
+
+
+
+# Main routine begins here.
+def main():
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logger.info("{}".format(__file__))
+    logger.info("Start time: {}".format(datetime.datetime.now()))
+
+    # retrieve and parse the command-line arguments
+    myArgs = getArgsDictionary(sys.argv[1:])
+    logger.info("Command line = {}".format(myArgs))
+
+    # set up the directories
+    waccmDir = None
+    if ("waccmDir" in myArgs):
+        waccmDir = myArgs.get("waccmDir")
+
+    musicaDir = None
+    if ("musicaDir" in myArgs):
+        musicaDir = myArgs.get("musicaDir")
+
+    # get the geographical location to retrieve
+    lat = None
+    if ("latitude" in myArgs):
+        lat = safeFloat(myArgs.get("latitude"))
+
+    lon = None
+    if ("longitude" in myArgs):
+        lon = safeFloat(myArgs.get("longitude"))
+
+    logger.info("Retrieve WACCM conditions at ({} North, {} East)."
+        .format(lat, lon))
+
+    logger.info("End time: {}".format(datetime.datetime.now()))
+    sys.exit(0)     # no error
+
+
+
+if (__name__ == "__main__"):
+    main()
+
+
+    logger.info("End time: {}".format(datetime.datetime.now()))
+    sys.exit(0)     # no error
+
+
+
+if (__name__ == "__main__"):
+    main()
+

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -77,13 +77,11 @@ def getMusicaDictionary():
    varMap = {
       "T": "temperature",
       "PS": "pressure",
-      "H2O": "H2O",
-      "TEPOMUC": "jtepo",   # test var not in WACCM
-      "BENZENE": "jbenzene",
+      "N2O": "N2O",
+      "H2O2": "H2O2",
       "O3": "O3",
       "NH3": "NH3",
-      "CH4": "CH4",
-      "O": "O"             # test var not in WACCM
+      "CH4": "CH4"
    }
 
    return(dict(sorted(varMap.items())))
@@ -155,7 +153,8 @@ unitIndex = 2
 def convertWaccm(varDict):
   # convert Ammonia to milli-moles
   nh3Tuple = varDict["NH3"]
-  varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[2])
+  varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[unitIndex])
+
   return(varDict)
 
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -75,6 +75,8 @@ def safeFloat(numString):
 # and their MusicBox equivalents.
 def getMusicaDictionary():
    varMap = {
+      "T": "temperature",
+      "PS": "pressure",
       "H2O": "H2O",
       "TEPOMUC": "jtepo",   # test var not in WACCM
       "BENZENE": "jbenzene",

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -8,9 +8,9 @@
 
 #import os
 import argparse
-#import numpy
 import datetime
 import xarray
+import json
 import sys
 
 import logging
@@ -132,9 +132,9 @@ def readWACCM(waccmMusicaDict, latitude, longitude,
 
     chemSinglePoint = singlePoint[waccmKey]
     if (True):
-      logger.info("{} = {}".format(waccmKey, chemSinglePoint))
-      logger.info("{} = {} {}".format(waccmKey, chemSinglePoint.values, chemSinglePoint.units))
-    musicaTuple = (waccmKey, chemSinglePoint.values, chemSinglePoint.units)
+      logger.info("{} = object {}".format(waccmKey, chemSinglePoint))
+      logger.info("{} = value {} {}".format(waccmKey, chemSinglePoint.values, chemSinglePoint.units))
+    musicaTuple = (waccmKey, float(chemSinglePoint.values.mean()), chemSinglePoint.units)
     musicaDict[musicaName] = musicaTuple
 
   # close the NetCDF file
@@ -195,11 +195,22 @@ def writeInitCSV(initValues, filename):
 # Write JSON fragment suitable for my_config.json in MusicBox.
 # initValues = dictionary of Musica varnames and (WACCM name, value, units)
 def writeInitJSON(initValues, filename):
-  fp = open(filename, "w")
 
-  fp.write("Hello, JSON World!\n")
+  # set up dictionary of vars and initial values
+  dictName = "chemical species"
+  initConfig = {dictName: {} }
 
-  fp.close()
+  for key, value in initValues.items():
+    initConfig[dictName][key] = {
+      "initial value [{}]".format(value[unitIndex]): value[valueIndex]}
+
+  # write JSON content to the file
+  fpJson = open(filename, "w")
+
+  json.dump(initConfig, fpJson, indent=2)
+  fpJson.close()
+
+  fpJson.close()
   return
 
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -12,6 +12,8 @@ import datetime
 import xarray
 import json
 import sys
+import os
+import shutil
 
 import logging
 logger = logging.getLogger(__name__)
@@ -214,6 +216,28 @@ def writeInitJSON(initValues, filename):
 
 
 
+# Reproduce the MusicBox configuration with new initial values.
+# initValues = dictionary of Musica varnames and (WACCM name, value, units)
+# templateDir = directory containing configuration files and camp_data
+# destDir = the template will be created in this directory
+def insertIntoTemplate(initValues, templateDir, destDir):
+
+  # copy the template directory to working area
+  destPath = os.path.basename(os.path.normpath(templateDir))
+  destPath = os.path.join(destDir, destPath)
+  logger.info("Create new configuration in = {}".format(destPath))
+
+  # remove directory if it already exists
+  if os.path.exists(destPath):
+    shutil.rmtree(destPath)
+
+  # copy the template directory
+  shutil.copytree(templateDir, destPath)
+
+  return
+
+
+
 # Main routine begins here.
 def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -254,6 +278,10 @@ def main():
     retrieveWhen = datetime.datetime.strptime(
       "{} {}".format(dateStr, timeStr), "%Y%m%d %H:%M")
 
+    template = None
+    if ("template" in myArgs):
+        template = myArgs.get("template")
+
     logger.info("Retrieve WACCM conditions at ({} North, {} East)   when {}."
         .format(lat, lon, retrieveWhen))
 
@@ -266,15 +294,19 @@ def main():
     varValues = convertWaccm(varValues)
     logger.info("Converted WACCM varValues = {}".format(varValues))
 
-    if (False):
+    if (True):
       # Write CSV file for MusicBox initial conditions.
       csvName = "{}/{}".format(musicaDir, "initial_conditions.csv")
       writeInitCSV(varValues, csvName)
 
-    else:
+    if (True):
       # Write JSON file for MusicBox initial conditions.
       jsonName = "{}/{}".format(musicaDir, "initial_config.json")
       writeInitJSON(varValues, jsonName)
+
+    if (True and template is not None):
+      logger.info("Insert values into template {}".format(template))
+      insertIntoTemplate(varValues, template, musicaDir)
 
     logger.info("End time: {}".format(datetime.datetime.now()))
     sys.exit(0)     # no error

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -282,6 +282,7 @@ def insertIntoTemplate(initValues, templateDir, destDir):
     root_dir=destDir, base_dir=destZip)
 
   # move into the created directory
+  shutil.move(destPath + ".zip", destPath)
 
   return
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -153,9 +153,14 @@ unitIndex = 2
 # varDict = originally read from WACCM, tuples are (musicaName, value, units)
 # return varDict with values modified
 def convertWaccm(varDict):
-  # convert Ammonia to milli-moles
-  nh3Tuple = varDict["NH3"]
-  varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[unitIndex])
+
+  moleToM3 = 1000 / 22.4
+
+  for key, vTuple in varDict.items():
+    # convert moles / mole to moles / cubic meter
+    units = vTuple[unitIndex]
+    if (units == "mol/mol"):
+      varDict[key] = (vTuple[0], vTuple[valueIndex] * moleToM3, "mol m-3")
 
   return(varDict)
 
@@ -242,7 +247,7 @@ def insertIntoTemplate(initValues, templateDir, destDir):
   # locate the section for chemical concentrations
   chemSpeciesTag = "chemical species"
   chemSpecies = myConfig[chemSpeciesTag]
-  logger.info("chemSpecies = {}".format(chemSpecies))
+  logger.info("Replace chemSpecies = {}".format(chemSpecies))
   del myConfig[chemSpeciesTag]     # delete the existing section
 
   # set up dictionary of chemicals and initial values

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -234,6 +234,44 @@ def insertIntoTemplate(initValues, templateDir, destDir):
   # copy the template directory
   shutil.copytree(templateDir, destPath)
 
+  # find the standard configuration file and parse it
+  myConfigFile = os.path.join(destPath, "my_config.json")
+  with open(myConfigFile) as jsonFile:
+    myConfig = json.load(jsonFile)
+
+  # locate the section for chemical concentrations
+  chemSpeciesTag = "chemical species"
+  chemSpecies = myConfig[chemSpeciesTag]
+  logger.info("chemSpecies = {}".format(chemSpecies))
+  del myConfig[chemSpeciesTag]     # delete the existing section
+
+  # set up dictionary of chemicals and initial values
+  chemValueDict = {}
+  temperature = 0.0
+  pressure = 0.0
+  for key, value in initValues.items():
+    if (key == "temperature"):
+      temperature = safeFloat(value[valueIndex])
+      continue
+    if (key == "pressure"):
+      pressure = safeFloat(value[valueIndex])
+      continue
+
+    chemValueDict[key] = {
+      "initial value [{}]".format(value[unitIndex]): value[valueIndex]}
+
+  myConfig[chemSpeciesTag] = chemValueDict
+
+  # replace the values of temperature and pressure
+  envConditionsTag = "environmental conditions"
+  envConfig = myConfig[envConditionsTag]
+  envConfig["temperature"]["initial value [K]"] = temperature
+  envConfig["pressure"]["initial value [Pa]"] = pressure
+
+  # save over the former json file
+  with open(myConfigFile, "w") as myConfigFile:
+    json.dump(myConfig, myConfigFile, indent=2)
+
   return
 
 

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -142,18 +142,51 @@ def readWACCM(waccmMusicaDict, latitude, longitude,
 
 
 
+# set up indexes for the tuple
+musicaIndex = 0
+valueIndex = 1
+unitIndex = 2
+
 # Perform any numeric conversion needed.
 # varDict = originally read from WACCM, tuples are (musicaName, value, units)
 # return varDict with values modified
 def convertWaccm(varDict):
-   # set up indexes for the tuple
-   musicaIndex = 0
-   valueIndex = 1
-   unitIndex = 2
+  # convert Ammonia to milli-moles
+  nh3Tuple = varDict["NH3"]
+  varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[2])
+  return(varDict)
 
-   nh3Tuple = varDict["NH3"]
-   varDict["NH3"] = (nh3Tuple[0], nh3Tuple[valueIndex] * 1000, "milli" + nh3Tuple[2])
-   return(varDict)
+
+
+# Write CSV file suitable for initial_conditions.csv in MusicBox
+# initValues = dictionary of Musica varnames and (WACCM name, value, units)
+def writeInitCSV(initValues, filename):
+  fp = open(filename, "w")
+
+  # write the column titles
+  firstColumn = True
+  for key, value in initValues.items():
+    if (firstColumn):
+      firstColumn = False
+    else:
+      fp.write(",")
+
+    fp.write(key)
+  fp.write("\n")
+
+  # write the variable values
+  firstColumn = True
+  for key, value in initValues.items():
+    if (firstColumn):
+      firstColumn = False
+    else:
+      fp.write(",")
+
+    fp.write("{}".format(value[valueIndex]))
+  fp.write("\n")
+
+  fp.close()
+  return
 
 
 
@@ -206,10 +239,12 @@ def main():
     logger.info("Original WACCM varValues = {}".format(varValues))
 
     # Perform any conversions needed, or derive variables.
-    convertWaccm(varValues)
+    varValues = convertWaccm(varValues)
     logger.info("Converted WACCM varValues = {}".format(varValues))
 
     # Write CSV file for MusicBox initial conditions.
+    csvName = "{}/{}".format(musicaDir, "initial_conditions.csv")
+    writeInitCSV(varValues, csvName)
 
     logger.info("End time: {}".format(datetime.datetime.now()))
     sys.exit(0)     # no error

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -134,7 +134,7 @@ def readWACCM(waccmMusicaDict, latitude, longitude,
     if (True):
       logger.info("{} = object {}".format(waccmKey, chemSinglePoint))
       logger.info("{} = value {} {}".format(waccmKey, chemSinglePoint.values, chemSinglePoint.units))
-    musicaTuple = (waccmKey, float(chemSinglePoint.values.mean()), chemSinglePoint.units)
+    musicaTuple = (waccmKey, float(chemSinglePoint.values.mean()), chemSinglePoint.units)   # from 0-dim array
     musicaDict[musicaName] = musicaTuple
 
   # close the NetCDF file

--- a/tools/waccmToMusicBox.py
+++ b/tools/waccmToMusicBox.py
@@ -160,7 +160,7 @@ def convertWaccm(varDict):
 
 
 
-# Write CSV file suitable for initial_conditions.csv in MusicBox
+# Write CSV file suitable for initial_conditions.csv in MusicBox.
 # initValues = dictionary of Musica varnames and (WACCM name, value, units)
 def writeInitCSV(initValues, filename):
   fp = open(filename, "w")
@@ -186,6 +186,18 @@ def writeInitCSV(initValues, filename):
 
     fp.write("{}".format(value[valueIndex]))
   fp.write("\n")
+
+  fp.close()
+  return
+
+
+
+# Write JSON fragment suitable for my_config.json in MusicBox.
+# initValues = dictionary of Musica varnames and (WACCM name, value, units)
+def writeInitJSON(initValues, filename):
+  fp = open(filename, "w")
+
+  fp.write("Hello, JSON World!\n")
 
   fp.close()
   return
@@ -244,9 +256,15 @@ def main():
     varValues = convertWaccm(varValues)
     logger.info("Converted WACCM varValues = {}".format(varValues))
 
-    # Write CSV file for MusicBox initial conditions.
-    csvName = "{}/{}".format(musicaDir, "initial_conditions.csv")
-    writeInitCSV(varValues, csvName)
+    if (False):
+      # Write CSV file for MusicBox initial conditions.
+      csvName = "{}/{}".format(musicaDir, "initial_conditions.csv")
+      writeInitCSV(varValues, csvName)
+
+    else:
+      # Write JSON file for MusicBox initial conditions.
+      jsonName = "{}/{}".format(musicaDir, "initial_config.json")
+      writeInitJSON(varValues, jsonName)
 
     logger.info("End time: {}".format(datetime.datetime.now()))
     sys.exit(0)     # no error


### PR DESCRIPTION
This is a stand-alone script that will run from the command line, apart from MusicBox. Calling sequence example is:

python3 waccmToMusicBox.py waccmDir="./model-output" musicaDir="./csvDir" date="20240301" time="07:00" latitude=3.1 longitude=101.7

For now, we place a JSON file with the initial values, and that section should be pasted into my_config.json. This script is intended for use during the demo on August 28.