### PR TITLE
adding ts1 as an example

### DIFF
--- a/src/acom_music_box/examples/configs/ts1/camp_data/config.json
+++ b/src/acom_music_box/examples/configs/ts1/camp_data/config.json
@@ -1,0 +1,6 @@
+{
+  "camp-files": [
+    "species.json",
+    "reactions.json"
+  ]
+}

--- a/src/acom_music_box/examples/configs/ts1/camp_data/reactions.json
+++ b/src/acom_music_box/examples/configs/ts1/camp_data/reactions.json
@@ -1,0 +1,6961 @@
+{
+  "__comments": [ "This mechanism may contain refactored reactions based on custom",
+                "rate constant functions in mo_usrrxt.F90 in the CAM source code.",
+                "As this file could change at any time, it is important that you",
+                "do an md5 checksum of mo_usrrxt.F90 from the version of CAM you",
+                "are using. The value should be: 9783938d6c5977f1c3603cadfe254987" ],
+  "camp-data": [
+    {
+      "name": "MZ327_TS1.2_20230307",
+      "type": "MECHANISM",
+      "reactions": [
+        {
+          "type": "TROE",
+          "k0_A": 5.5e-30,
+          "kinf_A": 8.3e-13,
+          "kinf_B": 2,
+          "reactants": {
+            "C2H2": { },
+            "OH": { }
+          },
+          "products": {
+            "GLYOXAL": { "yield": 0.65 },
+            "OH": { "yield": 0.65 },
+            "HCOOH": { "yield": 0.35 },
+            "HO2": { "yield": 0.35 },
+            "CO": { "yield": 0.35 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3O2": { },
+            "TERPO2": { }
+          },
+          "products": {
+            "TERPROD1": { },
+            "CH2O": { "yield": 0.95 },
+            "CH3OH": { "yield": 0.25 },
+            "HO2": { },
+            "CH3COCH3": { "yield": 0.025 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "C3H7OOH": { },
+            "OH": { }
+          },
+          "products": {
+            "H2O": { },
+            "C3H7O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jterpnit",
+          "reactants": {
+            "TERPNIT": { }
+          },
+          "products": {
+            "TERPROD1": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.45e-12,
+          "Ea": -3.03743e-21,
+          "reactants": {
+            "N": { },
+            "NO2": { }
+          },
+          "products": {
+            "N2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.4e-11,
+          "Ea": 2.20904e-20,
+          "reactants": {
+            "O": { },
+            "CH2O": { }
+          },
+          "products": {
+            "HO2": { },
+            "OH": { },
+            "CO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "TOLUO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.1364 },
+            "SOAG1": { "yield": 0.0101 },
+            "SOAG2": { "yield": 0.0763 },
+            "SOAG3": { "yield": 0.2157 },
+            "SOAG4": { "yield": 0.0738 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jo2_b",
+          "reactants": {
+            "O2": { }
+          },
+          "products": {
+            "O": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-12,
+          "Ea": 2.44375e-20,
+          "reactants": {
+            "OH": { },
+            "HCFC142B": { }
+          },
+          "products": {
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmgly",
+          "reactants": {
+            "CH3COCHO": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CO": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.17e-10,
+          "reactants": {
+            "CFC114": { },
+            "O1D": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jxylenooh",
+          "reactants": {
+            "XYLENOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.34 },
+            "CH3COCHO": { "yield": 0.54 },
+            "BIGALD1": { "yield": 0.06 },
+            "BIGALD2": { "yield": 0.2 },
+            "BIGALD3": { "yield": 0.15 },
+            "BIGALD4": { "yield": 0.21 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.1e-12,
+          "Ea": -3.72775e-21,
+          "reactants": {
+            "NO": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "CO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "reactants": {
+            "HONITR": { },
+            "OH": { }
+          },
+          "products": {
+            "ONITR": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.12e-13,
+          "Ea": -1.79484e-20,
+          "reactants": {
+            "ISOPO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.0031 },
+            "SOAG1": { "yield": 0.0035 },
+            "SOAG2": { "yield": 0.0003 },
+            "SOAG3": { "yield": 0.0271 },
+            "SOAG4": { "yield": 0.0474 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 0.81103,
+          "k0_B": -4.1,
+          "k0_C": -14000,
+          "kinf_A": 1.05545e17,
+          "kinf_C": -14000,
+          "kinf_B": -1.6,
+          "reactants": {
+            "PAN": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.9e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3CO3": { "qty": 2 }
+          },
+          "products": {
+            "CH3O2": { "yield": 2 },
+            "CO2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch4_b",
+          "reactants": {
+            "CH4": { }
+          },
+          "products": {
+            "H2": { "yield": 1.44 },
+            "CH2O": { "yield": 0.18 },
+            "O": { "yield": 0.18 },
+            "OH": { "yield": 0.33 },
+            "H": { "yield": 0.33 },
+            "CO2": { "yield": 0.44 },
+            "CO": { "yield": 0.38 },
+            "H2O": { "yield": 0.05 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.63e-10,
+          "Ea": -8.28389e-22,
+          "reactants": {
+            "H2O": { },
+            "O1D": { }
+          },
+          "products": {
+            "OH": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.0e-13,
+          "Ea": -3.17549e-21,
+          "reactants": {
+            "OH": { },
+            "CLO": { }
+          },
+          "products": {
+            "HCL": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-11,
+          "Ea": -6.07486e-21,
+          "reactants": {
+            "OH": { },
+            "MTERP": { }
+          },
+          "products": {
+            "MTERP": { },
+            "OH": { },
+            "MTERPO2VBS": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.8e-10,
+          "reactants": {
+            "CH3BR": { },
+            "O1D": { }
+          },
+          "products": {
+            "BR": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jterp2ooh",
+          "reactants": {
+            "TERP2OOH": { }
+          },
+          "products": {
+            "OH": { },
+            "CH2O": { "yield": 0.375 },
+            "CH3COCH3": { "yield": 0.3 },
+            "CO": { "yield": 0.25 },
+            "CO2": { },
+            "TERPROD2": { },
+            "HO2": { },
+            "GLYALD": { "yield": 0.25 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.34e-11,
+          "reactants": {
+            "SVOC": { },
+            "OH": { }
+          },
+          "products": {
+            "OH": { },
+            "SOAG0": { "yield": 0.5931 },
+            "SOAG1": { "yield": 0.1534 },
+            "SOAG2": { "yield": 0.0459 },
+            "SOAG3": { "yield": 0.0085 },
+            "SOAG4": { "yield": 0.0128 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "XYLENOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "XYLENO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.9e-11,
+          "reactants": {
+            "HCL": { },
+            "O1D": { }
+          },
+          "products": {
+            "CL": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbrono2_a",
+          "reactants": {
+            "BRONO2": { }
+          },
+          "products": {
+            "BR": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.7e-11,
+          "reactants": {
+            "SO": { },
+            "BRO": { }
+          },
+          "products": {
+            "SO2": { },
+            "BR": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "BENZO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "GLYOXAL": { },
+            "BIGALD1": { "yield": 0.5 },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "TOLO2": { },
+            "NO": { }
+          },
+          "products": {
+            "NO2": { },
+            "GLYOXAL": { "yield": 0.6 },
+            "CH3COCHO": { "yield": 0.4 },
+            "HO2": { },
+            "BIGALD1": { "yield": 0.2 },
+            "BIGALD2": { "yield": 0.2 },
+            "BIGALD3": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-10,
+          "reactants": {
+            "BCARY": { },
+            "OH": { }
+          },
+          "products": {
+            "BCARY": { },
+            "OH": { },
+            "BCARYO2VBS": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbigald4",
+          "reactants": {
+            "BIGALD4": { }
+          },
+          "products": {
+            "HO2": { },
+            "CO": { },
+            "CH3COCHO": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.75e-13,
+          "Ea": 5.5226e-22,
+          "reactants": {
+            "CH3O2": { },
+            "C3H7O2": { }
+          },
+          "products": {
+            "CH2O": { },
+            "HO2": { },
+            "CH3COCH3": { "yield": 0.82 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.65e-11,
+          "reactants": {
+            "O1D": { },
+            "HCFC22": { }
+          },
+          "products": {
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "Ea": 2.3471e-21,
+          "reactants": {
+            "MEK": { },
+            "OH": { }
+          },
+          "products": {
+            "MEKO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 8.796296296E-6,
+          "k0_B": -3.6,
+          "k0_C": -8537.0,
+          "kinf_A": 1.712962963E+15,
+          "kinf_B": -1.6,
+          "kinf_C": -8537.0,
+          "reactants": {
+            "CL2O2": { }
+          },
+          "products": {
+            "CLO": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "TOLOOH": { }
+          },
+          "products": {
+            "TOLO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa3_a2",
+          "reactants": {
+            "soa3_a2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.14e-11,
+          "reactants": {
+            "COF2": { },
+            "O1D": { }
+          },
+          "products": {
+            "F": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.54e-11,
+          "Ea": -5.66066e-21,
+          "reactants": {
+            "ISOP": { },
+            "OH": { }
+          },
+          "products": {
+            "ISOPAO2": { "yield": 0.6 },
+            "ISOPBO2": { "yield": 0.4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.29e-7,
+          "reactants": {
+            "E90": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.3e-16,
+          "Ea": 8.00776e-21,
+          "reactants": {
+            "O3": { },
+            "MTERP": { }
+          },
+          "products": {
+            "MTERP": { },
+            "O3": { },
+            "SOAG0": { "yield": 0.0508 },
+            "SOAG1": { "yield": 0.1149 },
+            "SOAG2": { "yield": 0.0348 },
+            "SOAG3": { "yield": 0.0554 },
+            "SOAG4": { "yield": 0.1278 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbro",
+          "reactants": {
+            "BRO": { }
+          },
+          "products": {
+            "BR": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3O2": { },
+            "MCO3": { }
+          },
+          "products": {
+            "CH2O": { "yield": 2 },
+            "HO2": { },
+            "CO2": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jtepomuc",
+          "reactants": {
+            "TEPOMUC": { }
+          },
+          "products": {
+            "CH3CO3": { "yield": 0.5 },
+            "HO2": { },
+            "CO": { "yield": 1.5 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.7e-29,
+          "k0_B": -5.6,
+          "kinf_A": 9.3e-12,
+          "kinf_B": -1.5,
+          "reactants": {
+            "MDIALO2": { },
+            "NO2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.96e-12,
+          "Ea": 1.65678e-20,
+          "reactants": {
+            "CH3CL": { },
+            "OH": { }
+          },
+          "products": {
+            "CL": { },
+            "H2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcof2",
+          "reactants": {
+            "COF2": { }
+          },
+          "products": {
+            "F": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch2o_b",
+          "reactants": {
+            "CH2O": { }
+          },
+          "products": {
+            "CO": { },
+            "H2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbrono2_b",
+          "reactants": {
+            "BRONO2": { }
+          },
+          "products": {
+            "BRO": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.4e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "ISOPBO2": { }
+          },
+          "products": {
+            "HYDRALD": { "yield": 0.87 },
+            "ISOPNITB": { "yield": 0.08 },
+            "NO2": { "yield": 0.92 },
+            "HO2": { "yield": 0.92 },
+            "GLYOXAL": { "yield": 0.05 },
+            "GLYALD": { "yield": 0.05 },
+            "CH3COCHO": { "yield": 0.05 },
+            "HYAC": { "yield": 0.05 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jno",
+          "reactants": {
+            "NO": { }
+          },
+          "products": {
+            "N": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3O2": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CH3O2": { "yield": 0.9 },
+            "CH2O": { },
+            "HO2": { "yield": 0.9 },
+            "CO2": { "yield": 0.9 },
+            "CH3COOH": { "yield": 0.1 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.5e-15,
+          "Ea": 2.89936e-20,
+          "reactants": {
+            "O3": { },
+            "MACR": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.12 },
+            "OH": { "yield": 0.24 },
+            "CO": { "yield": 0.65 },
+            "CH3CO3": { "yield": 0.1 },
+            "CH3COCHO": { "yield": 0.88 },
+            "HCOOH": { "yield": 0.33 },
+            "HO2": { "yield": 0.14 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "ALKOOH": { }
+          },
+          "products": {
+            "ALKO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.63e-12,
+          "Ea": -4.83227e-21,
+          "reactants": {
+            "OH": { },
+            "CH3CHO": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.75e-13,
+          "Ea": -1.79484e-20,
+          "reactants": {
+            "BCARYO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.2202 },
+            "SOAG1": { "yield": 0.2067 },
+            "SOAG2": { "yield": 0.0653 },
+            "SOAG3": { "yield": 0.1284 },
+            "SOAG4": { "yield": 0.114 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-12,
+          "Ea": -6.76518e-21,
+          "reactants": {
+            "NO3": { },
+            "MTERP": { }
+          },
+          "products": {
+            "NTERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.3e-12,
+          "Ea": 4.34904e-20,
+          "reactants": {
+            "N": { },
+            "O2": { }
+          },
+          "products": {
+            "NO": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -3.65872e-21,
+          "reactants": {
+            "HOCH2OO": { },
+            "NO": { }
+          },
+          "products": {
+            "HCOOH": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2o_b",
+          "reactants": {
+            "H2O": { }
+          },
+          "products": {
+            "H2": { },
+            "O1D": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jc3h7ooh",
+          "reactants": {
+            "C3H7OOH": { }
+          },
+          "products": {
+            "CH3COCH3": { "yield": 0.82 },
+            "OH": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcfc113",
+          "reactants": {
+            "CFC113": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COFCL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jccl4",
+          "reactants": {
+            "CCL4": { }
+          },
+          "products": {
+            "CL": { "yield": 4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.8e-11,
+          "reactants": {
+            "SO": { },
+            "CLO": { }
+          },
+          "products": {
+            "SO2": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jnoa",
+          "reactants": {
+            "NOA": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH2O": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.57e-10,
+          "reactants": {
+            "CH2BR2": { },
+            "O1D": { }
+          },
+          "products": {
+            "BR": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2so4",
+          "reactants": {
+            "H2SO4": { }
+          },
+          "products": {
+            "SO3": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.4e-13,
+          "Ea": -1.14594e-20,
+          "reactants": {
+            "OH": { },
+            "CH3COCHO": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CO": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-10,
+          "reactants": {
+            "O1D": { },
+            "COFCL": { }
+          },
+          "products": {
+            "F": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.64e-12,
+          "Ea": 2.09859e-20,
+          "reactants": {
+            "CH3CCL3": { },
+            "OH": { }
+          },
+          "products": {
+            "H2O": { },
+            "CL": { "yield": 3 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 6.1e-33,
+          "k0_B": -1.5,
+          "kinf_A": 9.8e-15,
+          "kinf_B": 4.6,
+          "Fc": 0.8,
+          "reactants": {
+            "OH": { },
+            "HCN": { }
+          },
+          "products": {
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.794e-10,
+          "reactants": {
+            "O1D": { },
+            "HCFC141B": { }
+          },
+          "products": {
+            "CL": { },
+            "COFCL": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmacr_b",
+          "reactants": {
+            "MACR": { }
+          },
+          "products": {
+            "HO2": { "yield": 0.66 },
+            "CO": { "yield": 1.34 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.0e-12,
+          "reactants": {
+            "CH4": { },
+            "O1D": { }
+          },
+          "products": {
+            "CH2O": { },
+            "H2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "C3H7O2": { },
+            "HO2": { }
+          },
+          "products": {
+            "C3H7OOH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jnterpooh",
+          "reactants": {
+            "NTERPOOH": { }
+          },
+          "products": {
+            "TERPROD1": { },
+            "NO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.54e-11,
+          "Ea": -5.66066e-21,
+          "reactants": {
+            "ISOP": { },
+            "OH": { }
+          },
+          "products": {
+            "ISOP": { },
+            "OH": { },
+            "ISOPO2VBS": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jrooh",
+          "reactants": {
+            "ROOH": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CH2O": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.7e-11,
+          "reactants": {
+            "OH": { },
+            "TERPROD1": { }
+          },
+          "products": {
+            "TERP2O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.45e-12,
+          "Ea": -3.03743e-21,
+          "reactants": {
+            "N": { },
+            "NO2": { }
+          },
+          "products": {
+            "NO": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhbr",
+          "reactants": {
+            "HBR": { }
+          },
+          "products": {
+            "BR": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-10,
+          "Ea": 6.48905e-21,
+          "reactants": {
+            "H": { },
+            "O3": { }
+          },
+          "products": {
+            "OH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "ISOPNO3": { },
+            "CH3O2": { }
+          },
+          "products": {
+            "NC4CHO": { "yield": 0.8 },
+            "HO2": { "yield": 1.2 },
+            "CH2O": { "yield": 0.8 },
+            "CH3OH": { "yield": 0.2 },
+            "NC4CH2OH": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "MDIALO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { "yield": 0.4 },
+            "HO2": { "yield": 0.33 },
+            "CH3COCHO": { "yield": 0.07 },
+            "CO": { "yield": 0.14 },
+            "CH3O2": { "yield": 0.07 },
+            "GLYOXAL": { "yield": 0.07 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jpooh",
+          "reactants": {
+            "POOH": { }
+          },
+          "products": {
+            "CH3CHO": { },
+            "CH2O": { },
+            "HO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "CH3O2": { },
+            "ISOPBO2": { }
+          },
+          "products": {
+            "CH3OH": { "yield": 0.25 },
+            "HO2": { },
+            "CH2O": { "yield": 0.75 },
+            "HYDRALD": { "yield": 0.75 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.1e-11,
+          "Ea": 3.86582e-21,
+          "reactants": {
+            "OH": { },
+            "DMS": { }
+          },
+          "products": {
+            "SO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa2_a2",
+          "reactants": {
+            "soa2_a2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "HOCH2OO": { },
+            "HO2": { }
+          },
+          "products": {
+            "HCOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-12,
+          "Ea": -6.76518e-21,
+          "reactants": {
+            "NO3": { },
+            "MTERP": { }
+          },
+          "products": {
+            "MTERP": { },
+            "NO3": { },
+            "SOAG3": { "yield": 0.17493 },
+            "SOAG4": { "yield": 0.59019 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.66e-12,
+          "Ea": 1.40826e-20,
+          "reactants": {
+            "C2H6": { },
+            "OH": { }
+          },
+          "products": {
+            "C2H5O2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.15e-11,
+          "reactants": {
+            "GLYOXAL": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { },
+            "CO": { },
+            "CO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "C6H5O2": { },
+            "HO2": { }
+          },
+          "products": {
+            "C6H5OOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-11,
+          "Ea": -6.07486e-21,
+          "reactants": {
+            "OH": { },
+            "MTERP": { }
+          },
+          "products": {
+            "TERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.52e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "XOOH": { }
+          },
+          "products": {
+            "XO2": { "yield": 0.5 },
+            "OH": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-12,
+          "Ea": 2.84414e-20,
+          "reactants": {
+            "O": { },
+            "O3": { }
+          },
+          "products": {
+            "O2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-11,
+          "reactants": {
+            "OH": { },
+            "IEPOX": { }
+          },
+          "products": {
+            "XO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.2e-11,
+          "Ea": 9.66454e-22,
+          "reactants": {
+            "C2H6": { },
+            "CL": { }
+          },
+          "products": {
+            "HCL": { },
+            "C2H5O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.4e-14,
+          "Ea": -1.20116e-20,
+          "reactants": {
+            "ALKO2": { },
+            "NO": { }
+          },
+          "products": {
+            "ALKNIT": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "BZOO": { },
+            "NO": { }
+          },
+          "products": {
+            "BZALD": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.8e-11,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "OH": { },
+            "O": { }
+          },
+          "products": {
+            "H": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-13,
+          "Ea": -7.17937e-21,
+          "reactants": {
+            "NO3": { },
+            "DMS": { }
+          },
+          "products": {
+            "SO2": { },
+            "HNO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "Ea": -7.31744e-21,
+          "reactants": {
+            "MCO3": { "qty": 2 }
+          },
+          "products": {
+            "CO2": { "yield": 2 },
+            "CH2O": { "yield": 2 },
+            "CH3CO3": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.8e-12,
+          "Ea": -1.65678e-21,
+          "reactants": {
+            "NO": { },
+            "ENEO2": { }
+          },
+          "products": {
+            "CH3CHO": { },
+            "CH2O": { "yield": 0.5 },
+            "CH3COCH3": { "yield": 0.5 },
+            "HO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.0e-34,
+          "B": -2.4,
+          "reactants": {
+            "O2": { },
+            "M": { },
+            "O": { }
+          },
+          "products": {
+            "O3": { },
+            "M": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.4e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "NO": { },
+            "CLO": { }
+          },
+          "products": {
+            "NO2": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "XO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "XOOH": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 2.9e-31,
+          "k0_B": -4.1,
+          "kinf_A": 1.7e-12,
+          "kinf_B": 0.2,
+          "reactants": {
+            "SO2": { },
+            "OH": { }
+          },
+          "products": {
+            "SO3": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.8e-30,
+          "k0_B": -3,
+          "kinf_A": 2.8e-11,
+          "reactants": {
+            "OH": { },
+            "NO2": { }
+          },
+          "products": {
+            "HNO3": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.8e-31,
+          "k0_B": -3.4,
+          "kinf_A": 1.5e-11,
+          "kinf_B": -1.9,
+          "reactants": {
+            "CLO": { },
+            "NO2": { }
+          },
+          "products": {
+            "CLONO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhyac",
+          "reactants": {
+            "HYAC": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "HO2": { },
+            "CH2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-11,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "O": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-12,
+          "Ea": -4.85988e-21,
+          "reactants": {
+            "TOLUENE": { },
+            "OH": { }
+          },
+          "products": {
+            "TOLUENE": { },
+            "OH": { },
+            "TOLUO2VBS": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.6e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "OH": { },
+            "MACR": { }
+          },
+          "products": {
+            "MACRO2": { "yield": 0.5 },
+            "H2O": { "yield": 0.5 },
+            "MCO3": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.204e-10,
+          "reactants": {
+            "CFC12": { },
+            "O1D": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-11,
+          "Ea": -3.17549e-21,
+          "reactants": {
+            "O": { },
+            "BRO": { }
+          },
+          "products": {
+            "BR": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.9e-12,
+          "reactants": {
+            "H": { },
+            "HO2": { }
+          },
+          "products": {
+            "H2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.5e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "HBR": { }
+          },
+          "products": {
+            "BR": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhcfc142b",
+          "reactants": {
+            "HCFC142B": { }
+          },
+          "products": {
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 8.0e-27,
+          "k0_B": -3.5,
+          "kinf_A": 3.0e-11,
+          "Fc": 0.5,
+          "reactants": {
+            "OH": { },
+            "C3H6": { }
+          },
+          "products": {
+            "PO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-10,
+          "reactants": {
+            "BCARY": { },
+            "OH": { }
+          },
+          "products": {
+            "TERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "MACRO2": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CH3COCHO": { "yield": 0.25 },
+            "CH3O2": { },
+            "CO": { "yield": 0.22 },
+            "HO2": { "yield": 0.47 },
+            "GLYALD": { "yield": 0.53 },
+            "HYAC": { "yield": 0.22 },
+            "CH2O": { "yield": 0.25 },
+            "CH3CO3": { "yield": 0.53 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 4.13793120e-04,
+          "k0_B": -3,
+          "k0_C": -10840,
+          "kinf_A": 2.7586208e+14,
+          "kinf_C": -10840,
+          "kinf_B": 0.1,
+          "reactants": {
+            "N2O5": { }
+          },
+          "products": {
+            "NO2": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-10,
+          "reactants": {
+            "O1D": { },
+            "H2": { }
+          },
+          "products": {
+            "H": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2o2",
+          "reactants": {
+            "H2O2": { }
+          },
+          "products": {
+            "OH": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-13,
+          "Ea": 3.14788e-20,
+          "reactants": {
+            "SO": { },
+            "O2": { }
+          },
+          "products": {
+            "SO2": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "C6H5OOH": { }
+          },
+          "products": {
+            "C6H5O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-13,
+          "reactants": {
+            "O": { },
+            "HOCL": { }
+          },
+          "products": {
+            "CLO": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.8e-13,
+          "reactants": {
+            "PHENO": { },
+            "O3": { }
+          },
+          "products": {
+            "C6H5O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "joclo",
+          "reactants": {
+            "OCLO": { }
+          },
+          "products": {
+            "O": { },
+            "CLO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "BENZO2VBS": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.0097 },
+            "SOAG1": { "yield": 0.0034 },
+            "SOAG2": { "yield": 0.1579 },
+            "SOAG3": { "yield": 0.0059 },
+            "SOAG4": { "yield": 0.0536 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "PHENO2": { },
+            "NO": { }
+          },
+          "products": {
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.7 },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "SO": { },
+            "NO2": { }
+          },
+          "products": {
+            "SO2": { },
+            "NO": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.9e-32,
+          "k0_B": -3.6,
+          "kinf_A": 3.7e-12,
+          "kinf_B": -1.6,
+          "reactants": {
+            "CLO": { "qty": 2 }
+          },
+          "products": {
+            "CL2O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa5_a2",
+          "reactants": {
+            "soa5_a2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "NO": { },
+            "ACBZO2": { }
+          },
+          "products": {
+            "C6H5O2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "Ea": -3.72775e-21,
+          "reactants": {
+            "CL": { },
+            "HO2": { }
+          },
+          "products": {
+            "HCL": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "PO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "POOH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "PHENO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "PHENOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "MCO3": { },
+            "HO2": { }
+          },
+          "products": {
+            "O3": { "yield": 0.15 },
+            "CH3COOH": { "yield": 0.15 },
+            "CH3COOOH": { "yield": 0.4 },
+            "OH": { "yield": 0.45 },
+            "CO2": { "yield": 0.45 },
+            "CH2O": { "yield": 0.45 },
+            "CH3CO3": { "yield": 0.45 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "C2H5O2": { }
+          },
+          "products": {
+            "CH3CHO": { },
+            "HO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmacr_a",
+          "reactants": {
+            "MACR": { }
+          },
+          "products": {
+            "HO2": { "yield": 1.34 },
+            "MCO3": { "yield": 0.66 },
+            "CH2O": { "yield": 1.34 },
+            "CH3CO3": { "yield": 1.34 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbenzooh",
+          "reactants": {
+            "BENZOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "GLYOXAL": { },
+            "BIGALD1": { "yield": 0.5 },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.07e-10,
+          "reactants": {
+            "O1D": { },
+            "CFC11": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COFCL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-13,
+          "reactants": {
+            "CH3O2": { },
+            "C2H5O2": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.7 },
+            "CH3CHO": { "yield": 0.8 },
+            "HO2": { },
+            "CH3OH": { "yield": 0.3 },
+            "C2H5OH": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jn2o5_b",
+          "reactants": {
+            "N2O5": { }
+          },
+          "products": {
+            "NO": { },
+            "O": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "ISOPBO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "ISOPOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.8e-12,
+          "Ea": 2.48517e-20,
+          "reactants": {
+            "OH": { },
+            "H2": { }
+          },
+          "products": {
+            "H2O": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-12,
+          "reactants": {
+            "H": { },
+            "HO2": { }
+          },
+          "products": {
+            "H2O": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.45e-12,
+          "Ea": 2.45065e-20,
+          "reactants": {
+            "CH4": { },
+            "OH": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jso",
+          "reactants": {
+            "SO": { }
+          },
+          "products": {
+            "S": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.83227e-21,
+          "reactants": {
+            "ISOPO2VBS": { },
+            "NO": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.0003 },
+            "SOAG1": { "yield": 0.0003 },
+            "SOAG2": { "yield": 0.0073 },
+            "SOAG3": { "yield": 0.0057 },
+            "SOAG4": { "yield": 0.0623 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.8e-11,
+          "Ea": -3.45162e-21,
+          "reactants": {
+            "OH": { },
+            "HO2": { }
+          },
+          "products": {
+            "H2O": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.1e-12,
+          "reactants": {
+            "PHENO": { },
+            "NO2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.5e-12,
+          "Ea": -3.17549e-21,
+          "reactants": {
+            "BRO": { "qty": 2 }
+          },
+          "products": {
+            "BR": { "yield": 2 },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.0e-11,
+          "reactants": {
+            "OH": { },
+            "NC4CH2OH": { }
+          },
+          "products": {
+            "GLYALD": { },
+            "NOA": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jisopnooh",
+          "reactants": {
+            "ISOPNOOH": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { },
+            "ISOPOOH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jalkooh",
+          "reactants": {
+            "ALKOOH": { }
+          },
+          "products": {
+            "CH3CHO": { "yield": 0.4 },
+            "CH2O": { "yield": 0.1 },
+            "CH3COCH3": { "yield": 0.25 },
+            "HO2": { "yield": 0.9 },
+            "MEK": { "yield": 0.8 },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.4e-12,
+          "Ea": -3.72775e-21,
+          "reactants": {
+            "OH": { },
+            "CLO": { }
+          },
+          "products": {
+            "CL": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "NTERPO2": { }
+          },
+          "products": {
+            "TERPNIT": { "yield": 0.2 },
+            "NO2": { "yield": 1.6 },
+            "TERPROD1": { "yield": 0.8 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-12,
+          "reactants": {
+            "NO3": { },
+            "TERPROD1": { }
+          },
+          "products": {
+            "TERP2O2": { "yield": 0.5 },
+            "NTERPO2": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa1_a1",
+          "reactants": {
+            "soa1_a1": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 8.6e-29,
+          "k0_B": -3.1,
+          "kinf_A": 9.0e-12,
+          "Fc": 0.48,
+          "kinf_B": -0.85,
+          "reactants": {
+            "C2H4": { },
+            "OH": { }
+          },
+          "products": {
+            "EO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 5.3e-32,
+          "k0_B": -1.8,
+          "kinf_A": 9.5e-11,
+          "kinf_B": 0.4,
+          "reactants": {
+            "O2": { },
+            "H": { }
+          },
+          "products": {
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "reactants": {
+            "S": { },
+            "O2": { }
+          },
+          "products": {
+            "SO": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-14,
+          "Ea": 3.63111e-20,
+          "reactants": {
+            "C2H4": { },
+            "O3": { }
+          },
+          "products": {
+            "CO": { "yield": 0.63 },
+            "OH": { "yield": 0.13 },
+            "HO2": { "yield": 0.13 },
+            "HCOOH": { "yield": 0.37 },
+            "CH2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.63e-7,
+          "reactants": {
+            "ST80_25": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-12,
+          "Ea": 4.55614e-21,
+          "reactants": {
+            "CLONO2": { },
+            "OH": { }
+          },
+          "products": {
+            "HOCL": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.1e-11,
+          "Ea": 3.03743e-20,
+          "reactants": {
+            "O": { },
+            "OCS": { }
+          },
+          "products": {
+            "SO": { },
+            "CO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "ISOPNO3": { },
+            "HO2": { }
+          },
+          "products": {
+            "ISOPNOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.13e-12,
+          "Ea": -6.24053e-21,
+          "reactants": {
+            "OH": { },
+            "MVK": { }
+          },
+          "products": {
+            "MACRO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jeooh",
+          "reactants": {
+            "EOOH": { }
+          },
+          "products": {
+            "EO": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "ISOPBO2": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "HYDRALD": { },
+            "CH3O2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbrcl",
+          "reactants": {
+            "BRCL": { }
+          },
+          "products": {
+            "BR": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "C2H5O2": { },
+            "HO2": { }
+          },
+          "products": {
+            "C2H5OOH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jisopooh",
+          "reactants": {
+            "ISOPOOH": { }
+          },
+          "products": {
+            "MVK": { "yield": 0.7 },
+            "MACR": { "yield": 0.3 },
+            "OH": { },
+            "CH2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-10,
+          "reactants": {
+            "H2402": { },
+            "O1D": { }
+          },
+          "products": {
+            "BR": { "yield": 2 },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.03e-12,
+          "Ea": 6.15769e-21,
+          "reactants": {
+            "ISOP": { },
+            "NO3": { }
+          },
+          "products": {
+            "ISOP": { },
+            "NO3": { },
+            "SOAG3": { "yield": 0.059024 },
+            "SOAG4": { "yield": 0.025024 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "CH3OOH": { }
+          },
+          "products": {
+            "CH3O2": { "yield": 0.7 },
+            "OH": { "yield": 0.3 },
+            "CH2O": { "yield": 0.3 },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jc6h5ooh",
+          "reactants": {
+            "C6H5OOH": { }
+          },
+          "products": {
+            "PHENO": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.1e-12,
+          "Ea": -2.89936e-21,
+          "reactants": {
+            "O": { },
+            "NO2": { }
+          },
+          "products": {
+            "NO": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "MEKOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "MEKO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.3e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "NO": { },
+            "MCO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH2O": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcfc114",
+          "reactants": {
+            "CFC114": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.7e-29,
+          "k0_B": -5.6,
+          "kinf_A": 9.3e-12,
+          "kinf_B": -1.5,
+          "reactants": {
+            "MALO2": { },
+            "NO2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.44e-12,
+          "Ea": -3.58969e-21,
+          "reactants": {
+            "NO": { },
+            "HO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jho2no2_b",
+          "reactants": {
+            "HO2NO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.25e-12,
+          "Ea": 2.20904e-20,
+          "reactants": {
+            "OH": { },
+            "HCFC141B": { }
+          },
+          "products": {
+            "CL": { },
+            "COFCL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "Ea": -3.58969e-21,
+          "reactants": {
+            "BRO": { },
+            "CLO": { }
+          },
+          "products": {
+            "BR": { },
+            "CL": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jpan",
+          "reactants": {
+            "PAN": { }
+          },
+          "products": {
+            "CH3CO3": { "yield": 0.6 },
+            "NO2": { "yield": 0.6 },
+            "CH3O2": { "yield": 0.4 },
+            "NO3": { "yield": 0.4 },
+            "CO2": { "yield": 0.4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.0e-11,
+          "reactants": {
+            "OH": { },
+            "ISOPNITA": { }
+          },
+          "products": {
+            "HYAC": { "yield": 0.7 },
+            "GLYALD": { "yield": 0.7 },
+            "NO2": { "yield": 0.7 },
+            "CH2O": { "yield": 0.3 },
+            "HONITR": { "yield": 0.3 },
+            "HO2": { "yield": 0.3 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "PO2": { }
+          },
+          "products": {
+            "CH3CHO": { },
+            "CH2O": { },
+            "HO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "BENZO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.0023 },
+            "SOAG1": { "yield": 0.0008 },
+            "SOAG2": { "yield": 0.0843 },
+            "SOAG3": { "yield": 0.0443 },
+            "SOAG4": { "yield": 0.1621 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jo3_b",
+          "reactants": {
+            "O3": { }
+          },
+          "products": {
+            "O": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-14,
+          "Ea": 6.76518e-21,
+          "reactants": {
+            "O3": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { },
+            "O2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcf2cl2",
+          "reactants": {
+            "CFC12": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.62e-10,
+          "reactants": {
+            "CHBR3": { },
+            "O1D": { }
+          },
+          "products": {
+            "BR": { "yield": 3 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jno3_b",
+          "reactants": {
+            "NO3": { }
+          },
+          "products": {
+            "NO": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbigald2",
+          "reactants": {
+            "BIGALD2": { }
+          },
+          "products": {
+            "HO2": { "yield": 0.6 },
+            "DICARBO2": { "yield": 0.6 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-13,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "NO": { },
+            "MACRO2": { }
+          },
+          "products": {
+            "HONITR": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.5e-11,
+          "reactants": {
+            "O1D": { },
+            "CF3BR": { }
+          },
+          "products": {
+            "BR": { },
+            "F": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "BENZOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "BENZO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.7e-29,
+          "k0_B": -5.6,
+          "kinf_A": 9.3e-12,
+          "kinf_B": -1.5,
+          "reactants": {
+            "ACBZO2": { },
+            "NO2": { }
+          },
+          "products": {
+            "PBZNIT": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "TERPO2": { }
+          },
+          "products": {
+            "TERPNIT": { "yield": 0.2 },
+            "NO2": { "yield": 0.8 },
+            "CH2O": { "yield": 0.32 },
+            "CH3COCH3": { "yield": 0.04 },
+            "TERPROD1": { "yield": 0.8 },
+            "HO2": { "yield": 0.8 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.6e-11,
+          "reactants": {
+            "OH": { },
+            "S": { }
+          },
+          "products": {
+            "SO": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-12,
+          "reactants": {
+            "CH3COOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "CH3CO3": { "yield": 0.5 },
+            "CH2O": { "yield": 0.5 },
+            "CO2": { "yield": 0.5 },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.3e-11,
+          "Ea": -7.59357e-22,
+          "reactants": {
+            "O1D": { },
+            "O2": { }
+          },
+          "products": {
+            "O": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-14,
+          "Ea": -6.35099e-21,
+          "reactants": {
+            "HNO3": { },
+            "OH": { }
+          },
+          "products": {
+            "NO3": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 6.5e-34,
+          "k0_C": 1335,
+          "kinf_A": 2.7e-17,
+          "kinf_C": 2199,
+          "Fc": 1,
+          "reactants": {
+            "HNO3": { },
+            "OH": { }
+          },
+          "products": {
+            "NO3": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jho2no2_a",
+          "reactants": {
+            "HO2NO2": { }
+          },
+          "products": {
+            "OH": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3br",
+          "reactants": {
+            "CH3BR": { }
+          },
+          "products": {
+            "BR": { },
+            "CH3O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "CLO": { },
+            "HO2": { }
+          },
+          "products": {
+            "O2": { },
+            "HOCL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "NO": { },
+            "MDIALO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { "yield": 0.83 },
+            "CH3COCHO": { "yield": 0.17 },
+            "CO": { "yield": 0.35 },
+            "CH3O2": { "yield": 0.17 },
+            "GLYOXAL": { "yield": 0.17 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "H2O": { },
+            "F": { }
+          },
+          "products": {
+            "HF": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-12,
+          "Ea": 2.56801e-20,
+          "reactants": {
+            "NO3": { },
+            "CH3COCHO": { }
+          },
+          "products": {
+            "HNO3": { },
+            "CO": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jclono2_b",
+          "reactants": {
+            "CLONO2": { }
+          },
+          "products": {
+            "CLO": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.1e-11,
+          "Ea": -1.38065e-21,
+          "reactants": {
+            "NO": { },
+            "N": { }
+          },
+          "products": {
+            "N2": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.9e-12,
+          "Ea": 4.76324e-21,
+          "reactants": {
+            "CH3OH": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { },
+            "CH2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "CH3O2": { },
+            "XO2": { }
+          },
+          "products": {
+            "CH3OH": { "yield": 0.3 },
+            "HO2": { "yield": 0.8 },
+            "CH2O": { "yield": 0.8 },
+            "CO": { "yield": 0.2 },
+            "GLYOXAL": { "yield": 0.1 },
+            "CH3COCHO": { "yield": 0.1 },
+            "HYAC": { "yield": 0.1 },
+            "GLYALD": { "yield": 0.1 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "PHENOOH": { }
+          },
+          "products": {
+            "PHENO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "ISOPNO3": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "NC4CHO": { },
+            "CH3O2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jglyoxal",
+          "reactants": {
+            "GLYOXAL": { }
+          },
+          "products": {
+            "CO": { "yield": 2 },
+            "HO2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jo3_a",
+          "reactants": {
+            "O3": { }
+          },
+          "products": {
+            "O1D": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "XYLENO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.34 },
+            "CH3COCHO": { "yield": 0.54 },
+            "BIGALD1": { "yield": 0.06 },
+            "BIGALD2": { "yield": 0.2 },
+            "BIGALD3": { "yield": 0.15 },
+            "BIGALD4": { "yield": 0.21 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "XYLOLOOH": { }
+          },
+          "products": {
+            "XYLOLO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-12,
+          "reactants": {
+            "OH": { },
+            "HYAC": { }
+          },
+          "products": {
+            "CH3COCHO": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.0e-13,
+          "Ea": 2.84138e-20,
+          "reactants": {
+            "NO3": { },
+            "CH2O": { }
+          },
+          "products": {
+            "CO": { },
+            "HO2": { },
+            "HNO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "MALO2": { },
+            "NO": { }
+          },
+          "products": {
+            "GLYOXAL": { "yield": 0.4 },
+            "HO2": { "yield": 0.4 },
+            "CO": { "yield": 0.4 },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "ALKO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "ALKOOH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jn2o5_a",
+          "reactants": {
+            "N2O5": { }
+          },
+          "products": {
+            "NO2": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-11,
+          "reactants": {
+            "OH": { },
+            "TERPNIT": { }
+          },
+          "products": {
+            "NO2": { },
+            "TERPROD1": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhpald",
+          "reactants": {
+            "HPALD": { }
+          },
+          "products": {
+            "BIGALD3": { },
+            "OH": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e+12,
+          "Ea": 9.66454e-20,
+          "reactants": {
+            "HOCH2OO": { }
+          },
+          "products": {
+            "CH2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.1e-13,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "BRO": { },
+            "CLO": { }
+          },
+          "products": {
+            "BRCL": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "ISOPAO2": { },
+            "CH3O2": { }
+          },
+          "products": {
+            "CH3OH": { "yield": 0.25 },
+            "HO2": { },
+            "CH2O": { "yield": 1.5 },
+            "MACR": { "yield": 0.31 },
+            "MVK": { "yield": 0.44 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbzooh",
+          "reactants": {
+            "BZOOH": { }
+          },
+          "products": {
+            "BZALD": { },
+            "OH": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-12,
+          "Ea": 2.7613e-20,
+          "reactants": {
+            "O": { },
+            "H2O2": { }
+          },
+          "products": {
+            "OH": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-14,
+          "reactants": {
+            "EO": { },
+            "O2": { }
+          },
+          "products": {
+            "GLYALD": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.64e-11,
+          "Ea": -2.7613e-22,
+          "reactants": {
+            "N2O": { },
+            "O1D": { }
+          },
+          "products": {
+            "N2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.86e-11,
+          "Ea": -2.41614e-21,
+          "reactants": {
+            "OH": { },
+            "HPALD": { }
+          },
+          "products": {
+            "XO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcl2o2",
+          "reactants": {
+            "CL2O2": { }
+          },
+          "products": {
+            "CL": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-10,
+          "Ea": 5.93679e-21,
+          "reactants": {
+            "HOBR": { },
+            "O": { }
+          },
+          "products": {
+            "BRO": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.7e-15,
+          "Ea": -8.62906e-21,
+          "reactants": {
+            "CH2O": { },
+            "HO2": { }
+          },
+          "products": {
+            "HOCH2OO": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 5.2e-30,
+          "k0_B": -2.4,
+          "kinf_A": 2.2e-10,
+          "kinf_B": -0.7,
+          "reactants": {
+            "C2H2": { },
+            "CL": { }
+          },
+          "products": {
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "ISOPNO3": { },
+            "NO3": { }
+          },
+          "products": {
+            "NC4CHO": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.34e-11,
+          "reactants": {
+            "IVOC": { },
+            "OH": { }
+          },
+          "products": {
+            "OH": { },
+            "IVOCO2VBS": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jalknit",
+          "reactants": {
+            "ALKNIT": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH3CHO": { "yield": 0.4 },
+            "CH2O": { "yield": 0.1 },
+            "CH3COCH3": { "yield": 0.25 },
+            "HO2": { },
+            "MEK": { "yield": 0.8 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.5e-12,
+          "reactants": {
+            "NO3": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { },
+            "NO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.03e-11,
+          "Ea": 1.51871e-20,
+          "reactants": {
+            "CH3CL": { },
+            "CL": { }
+          },
+          "products": {
+            "HO2": { },
+            "CO": { },
+            "HCL": { "yield": 2 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.7e-29,
+          "k0_B": -5.6,
+          "kinf_A": 9.3e-12,
+          "kinf_B": -1.5,
+          "reactants": {
+            "MCO3": { },
+            "NO2": { }
+          },
+          "products": {
+            "MPAN": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.0e-13,
+          "Ea": 4.97034e-21,
+          "reactants": {
+            "CHBR3": { },
+            "OH": { }
+          },
+          "products": {
+            "BR": { "yield": 3 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-10,
+          "reactants": {
+            "O1D": { },
+            "HCFC142B": { }
+          },
+          "products": {
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.3e-12,
+          "Ea": 1.58775e-21,
+          "reactants": {
+            "CH3O2": { },
+            "CLO": { }
+          },
+          "products": {
+            "CL": { },
+            "HO2": { },
+            "CH2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.5e-13,
+          "Ea": 1.89149e-20,
+          "reactants": {
+            "CLO": { "qty": 2 }
+          },
+          "products": {
+            "CL": { },
+            "OCLO": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbigald",
+          "reactants": {
+            "BIGALD": { }
+          },
+          "products": {
+            "CO": { "yield": 0.45 },
+            "GLYOXAL": { "yield": 0.13 },
+            "HO2": { "yield": 0.56 },
+            "CH3CO3": { "yield": 0.13 },
+            "CH3COCHO": { "yield": 0.18 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.6e-11,
+          "Ea": 5.17743e-21,
+          "reactants": {
+            "CL": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { },
+            "CLO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "C3H7O2": { }
+          },
+          "products": {
+            "CH3COCH3": { "yield": 0.82 },
+            "NO2": { },
+            "HO2": { },
+            "CH3CHO": { "yield": 0.27 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa5_a1",
+          "reactants": {
+            "soa5_a1": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.9e-12,
+          "Ea": 3.17549e-21,
+          "reactants": {
+            "C2H5OH": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { },
+            "CH3CHO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-11,
+          "reactants": {
+            "O3": { },
+            "S": { }
+          },
+          "products": {
+            "SO": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 7.3e-29,
+          "k0_B": -4.1,
+          "kinf_A": 9.5e-12,
+          "kinf_B": -1.6,
+          "reactants": {
+            "CH3CO3": { },
+            "NO2": { }
+          },
+          "products": {
+            "PAN": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.52e-11,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "ISOPOOH": { }
+          },
+          "products": {
+            "XO2": { "yield": 0.4 },
+            "IEPOX": { "yield": 0.6 },
+            "OH": { "yield": 0.6 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.9e-12,
+          "Ea": -4.14195e-21,
+          "reactants": {
+            "NO": { },
+            "RO2": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CH2O": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "BZOOH": { }
+          },
+          "products": {
+            "BZOO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-10,
+          "reactants": {
+            "O3": { },
+            "O1D": { }
+          },
+          "products": {
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "MALO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "GLYOXAL": { "yield": 0.16 },
+            "HO2": { "yield": 0.16 },
+            "CO": { "yield": 0.16 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.31e-7,
+          "reactants": {
+            "NH_50": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.15e-11,
+          "Ea": -1.51871e-21,
+          "reactants": {
+            "O1D": { },
+            "N2": { }
+          },
+          "products": {
+            "O": { },
+            "N2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-11,
+          "reactants": {
+            "OH": { },
+            "XYLENES": { }
+          },
+          "products": {
+            "XYLOL": { "yield": 0.15 },
+            "TEPOMUC": { "yield": 0.23 },
+            "BZOO": { "yield": 0.06 },
+            "XYLENO2": { "yield": 0.56 },
+            "HO2": { "yield": 0.38 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.2e-11,
+          "reactants": {
+            "NO3": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "IVOCO2VBS": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.1056 },
+            "SOAG1": { "yield": 0.1026 },
+            "SOAG2": { "yield": 0.0521 },
+            "SOAG3": { "yield": 0.0143 },
+            "SOAG4": { "yield": 0.0166 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "BCARYO2VBS": { },
+            "NO": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.1279 },
+            "SOAG1": { "yield": 0.1792 },
+            "SOAG2": { "yield": 0.0676 },
+            "SOAG3": { "yield": 0.079 },
+            "SOAG4": { "yield": 0.1254 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmvk",
+          "reactants": {
+            "MVK": { }
+          },
+          "products": {
+            "C3H6": { "yield": 0.7 },
+            "CO": { "yield": 0.7 },
+            "CH3O2": { "yield": 0.3 },
+            "CH3CO3": { "yield": 0.3 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "EO2": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.5 },
+            "HO2": { "yield": 0.25 },
+            "EO": { "yield": 0.75 },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-11,
+          "reactants": {
+            "O1D": { },
+            "HBR": { }
+          },
+          "products": {
+            "BRO": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.8e-11,
+          "Ea": -1.17355e-21,
+          "reactants": {
+            "O": { },
+            "CLO": { }
+          },
+          "products": {
+            "CL": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.1e-12,
+          "Ea": 1.75342e-20,
+          "reactants": {
+            "CH4": { },
+            "CL": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "HCL": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jso3",
+          "reactants": {
+            "SO3": { }
+          },
+          "products": {
+            "SO2": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.3e-12,
+          "Ea": 1.10452e-20,
+          "reactants": {
+            "CH2BR2": { },
+            "CL": { }
+          },
+          "products": {
+            "BR": { "yield": 2 },
+            "HCL": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 8.0e-27,
+          "k0_B": -3.5,
+          "kinf_A": 3.0e-11,
+          "Fc": 0.5,
+          "reactants": {
+            "OH": { },
+            "MPAN": { }
+          },
+          "products": {
+            "HYAC": { "yield": 0.5 },
+            "NO3": { "yield": 0.5 },
+            "CH2O": { "yield": 0.5 },
+            "HO2": { "yield": 0.5 },
+            "CO2": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.07767,
+          "k0_B": -5.6,
+          "k0_C": -14000,
+          "kinf_A": 1.03323e+17,
+          "kinf_B": -1.5,
+          "kinf_C": -14000,
+          "reactants": {
+            "PBZNIT": { }
+          },
+          "products": {
+            "ACBZO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-12,
+          "Ea": 6.90325e-21,
+          "reactants": {
+            "OH": { },
+            "HOCL": { }
+          },
+          "products": {
+            "H2O": { },
+            "CLO": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jchbr3",
+          "reactants": {
+            "CHBR3": { }
+          },
+          "products": {
+            "BR": { "yield": 3 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-12,
+          "Ea": 2.62323e-20,
+          "reactants": {
+            "NO3": { },
+            "CH3CHO": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "HNO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jterprd2",
+          "reactants": {
+            "TERPROD2": { }
+          },
+          "products": {
+            "RO2": { "yield": 0.15 },
+            "CH2O": { "yield": 0.68 },
+            "CO2": { "yield": 0.8 },
+            "CH3COCH3": { "yield": 0.5 },
+            "CH3CO3": { "yield": 0.65 },
+            "HO2": { "yield": 1.2 },
+            "CO": { "yield": 1.7 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "MACRO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "MACROOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.8e-12,
+          "Ea": 4.28001e-21,
+          "reactants": {
+            "BR": { },
+            "HO2": { }
+          },
+          "products": {
+            "HBR": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "NO": { },
+            "MACRO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { "yield": 0.47 },
+            "CH2O": { "yield": 0.25 },
+            "GLYALD": { "yield": 0.53 },
+            "CH3COCHO": { "yield": 0.25 },
+            "CH3CO3": { "yield": 0.53 },
+            "HYAC": { "yield": 0.22 },
+            "CO": { "yield": 0.22 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.05e-14,
+          "Ea": 2.7613e-20,
+          "reactants": {
+            "ISOP": { },
+            "O3": { }
+          },
+          "products": {
+            "ISOP": { },
+            "O3": { },
+            "SOAG3": { "yield": 0.0033 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmek",
+          "reactants": {
+            "MEK": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "C2H5O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jacet",
+          "reactants": {
+            "CH3COCH3": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CH3O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-12,
+          "reactants": {
+            "SO": { },
+            "OCLO": { }
+          },
+          "products": {
+            "SO2": { },
+            "CLO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "ACBZO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "C6H5O2": { "yield": 0.4 },
+            "OH": { "yield": 0.4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "XYLEO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.1677 },
+            "SOAG1": { "yield": 0.0174 },
+            "SOAG2": { "yield": 0.086 },
+            "SOAG3": { "yield": 0.0512 },
+            "SOAG4": { "yield": 0.1598 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.9e-12,
+          "Ea": -3.10646e-21,
+          "reactants": {
+            "BZALD": { },
+            "OH": { }
+          },
+          "products": {
+            "ACBZO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-10,
+          "Ea": 3.58969e-21,
+          "reactants": {
+            "CH4": { },
+            "F": { }
+          },
+          "products": {
+            "HF": { },
+            "CH3O2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.0e-32,
+          "k0_B": -1.5,
+          "kinf_A": 3.0e-11,
+          "reactants": {
+            "NO": { },
+            "O": { }
+          },
+          "products": {
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.31e-6,
+          "reactants": {
+            "NH_5": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-11,
+          "reactants": {
+            "ISOPAO2": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "HO2": { },
+            "CH2O": { },
+            "MACR": { "yield": 0.39 },
+            "MVK": { "yield": 0.61 },
+            "CO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.82e-11,
+          "Ea": 2.7613e-20,
+          "reactants": {
+            "CH3COCH3": { },
+            "OH": { }
+          },
+          "products": {
+            "RO2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.33e-13,
+          "reactants": {
+            "CH3COCH3": { },
+            "OH": { }
+          },
+          "products": {
+            "RO2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.5e-13,
+          "Ea": -8.42196e-21,
+          "reactants": {
+            "HO2NO2": { },
+            "OH": { }
+          },
+          "products": {
+            "H2O": { },
+            "NO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-11,
+          "reactants": {
+            "NO3": { },
+            "O": { }
+          },
+          "products": {
+            "NO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.7e-12,
+          "reactants": {
+            "ALKO2": { },
+            "NO": { }
+          },
+          "products": {
+            "CH3CHO": { "yield": 0.4 },
+            "CH2O": { "yield": 0.1 },
+            "CH3COCH3": { "yield": 0.25 },
+            "HO2": { },
+            "MEK": { "yield": 0.8 },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.9e-31,
+          "k0_B": -3.4,
+          "kinf_A": 4.0e-12,
+          "kinf_B": -0.3,
+          "reactants": {
+            "NO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcf2clbr",
+          "reactants": {
+            "CF2CLBR": { }
+          },
+          "products": {
+            "BR": { },
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2o_c",
+          "reactants": {
+            "H2O": { }
+          },
+          "products": {
+            "H": { "yield": 2 },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.0e-11,
+          "reactants": {
+            "ISOPNITB": { },
+            "OH": { }
+          },
+          "products": {
+            "HYAC": { "yield": 0.5 },
+            "GLYALD": { "yield": 0.5 },
+            "NOA": { "yield": 0.5 },
+            "HO2": { },
+            "HONITR": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.4e-11,
+          "reactants": {
+            "OH": { },
+            "XYLOL": { }
+          },
+          "products": {
+            "XYLOLO2": { "yield": 0.3 },
+            "HO2": { "yield": 0.63 },
+            "PHENO": { "yield": 0.07 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-11,
+          "Ea": -4.55614e-21,
+          "reactants": {
+            "SO": { },
+            "OH": { }
+          },
+          "products": {
+            "SO2": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.6e-12,
+          "Ea": -7.31744e-21,
+          "reactants": {
+            "MCO3": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CO2": { "yield": 2 },
+            "CH3O2": { },
+            "CH2O": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jxylolooh",
+          "reactants": {
+            "XYLOLOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "GLYOXAL": { "yield": 0.17 },
+            "CH3COCHO": { "yield": 0.51 },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jso2",
+          "reactants": {
+            "SO2": { }
+          },
+          "products": {
+            "SO": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmekooh",
+          "reactants": {
+            "MEKOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "CH3CO3": { },
+            "CH3CHO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-11,
+          "reactants": {
+            "OH": { },
+            "XYLENES": { }
+          },
+          "products": {
+            "XYLENES": { },
+            "OH": { },
+            "XYLEO2VBS": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.4e-12,
+          "Ea": 1.79484e-21,
+          "reactants": {
+            "HOCL": { },
+            "CL": { }
+          },
+          "products": {
+            "HCL": { },
+            "CLO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.7e-11,
+          "reactants": {
+            "CRESOL": { },
+            "OH": { }
+          },
+          "products": {
+            "PHENO2": { "yield": 0.2 },
+            "HO2": { "yield": 0.73 },
+            "PHENO": { "yield": 0.07 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.15e-14,
+          "Ea": -1.2702e-20,
+          "reactants": {
+            "OH": { },
+            "CH3COOH": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "CO2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jphenooh",
+          "reactants": {
+            "PHENOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.7 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.8e-12,
+          "reactants": {
+            "OH": { "qty": 2 }
+          },
+          "products": {
+            "H2O": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-11,
+          "Ea": 3.38259e-20,
+          "reactants": {
+            "CLO": { "qty": 2 }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.3e-12,
+          "Ea": -8.83615e-21,
+          "reactants": {
+            "XO2": { },
+            "CH3CO3": { }
+          },
+          "products": {
+            "CO": { "yield": 0.25 },
+            "CH2O": { "yield": 0.25 },
+            "GLYOXAL": { "yield": 0.25 },
+            "CH3O2": { },
+            "HO2": { },
+            "CH3COCHO": { "yield": 0.25 },
+            "HYAC": { "yield": 0.25 },
+            "GLYALD": { "yield": 0.25 },
+            "CO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "NO3": { },
+            "XO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { },
+            "CO": { "yield": 0.5 },
+            "HYAC": { "yield": 0.25 },
+            "GLYOXAL": { "yield": 0.25 },
+            "CH3COCHO": { "yield": 0.25 },
+            "GLYALD": { "yield": 0.25 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "TERP2O2": { },
+            "NO": { }
+          },
+          "products": {
+            "ONITR": { "yield": 0.1 },
+            "NO2": { "yield": 0.9 },
+            "CH2O": { "yield": 0.34 },
+            "CH3COCH3": { "yield": 0.27 },
+            "CO": { "yield": 0.225 },
+            "CO2": { "yield": 0.9 },
+            "TERPROD2": { "yield": 0.9 },
+            "HO2": { "yield": 0.9 },
+            "GLYALD": { "yield": 0.225 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.42e-12,
+          "Ea": 1.58775e-20,
+          "reactants": {
+            "CH3BR": { },
+            "OH": { }
+          },
+          "products": {
+            "BR": { },
+            "H2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa4_a1",
+          "reactants": {
+            "soa4_a1": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jno2",
+          "reactants": {
+            "NO2": { }
+          },
+          "products": {
+            "NO": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-11,
+          "reactants": {
+            "OH": { },
+            "GLYALD": { }
+          },
+          "products": {
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.2 },
+            "CH2O": { "yield": 0.8 },
+            "CO2": { "yield": 0.8 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "NTERPO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "NTERPOOH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbigald3",
+          "reactants": {
+            "BIGALD3": { }
+          },
+          "products": {
+            "HO2": { "yield": 0.6 },
+            "CO": { "yield": 0.6 },
+            "MDIALO2": { "yield": 0.6 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "POOH": { }
+          },
+          "products": {
+            "PO2": { "yield": 0.5 },
+            "OH": { "yield": 0.5 },
+            "HYAC": { "yield": 0.5 },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.75e-11,
+          "reactants": {
+            "O1D": { },
+            "CF2CLBR": { }
+          },
+          "products": {
+            "CL": { },
+            "BR": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch2br2",
+          "reactants": {
+            "CH2BR2": { }
+          },
+          "products": {
+            "BR": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhf",
+          "reactants": {
+            "HF": { }
+          },
+          "products": {
+            "H": { },
+            "F": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbepomuc",
+          "reactants": {
+            "BEPOMUC": { }
+          },
+          "products": {
+            "BIGALD1": { },
+            "HO2": { "yield": 1.5 },
+            "CO": { "yield": 1.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.6e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "RO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "ROOH": { "yield": 0.85 },
+            "OH": { "yield": 0.15 },
+            "CH2O": { "yield": 0.15 },
+            "CH3CO3": { "yield": 0.15 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "NO3": { },
+            "MACRO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { "yield": 0.47 },
+            "CH2O": { "yield": 0.25 },
+            "CH3COCHO": { "yield": 0.25 },
+            "CO": { "yield": 0.22 },
+            "GLYALD": { "yield": 0.53 },
+            "HYAC": { "yield": 0.22 },
+            "CH3CO3": { "yield": 0.53 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3O2": { },
+            "NTERPO2": { }
+          },
+          "products": {
+            "TERPNIT": { "yield": 0.5 },
+            "CH2O": { "yield": 0.75 },
+            "CH3OH": { "yield": 0.25 },
+            "HO2": { "yield": 0.5 },
+            "TERPROD1": { "yield": 0.5 },
+            "NO2": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-11,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "MACROOH": { },
+            "OH": { }
+          },
+          "products": {
+            "MCO3": { "yield": 0.5 },
+            "MACRO2": { "yield": 0.2 },
+            "OH": { "yield": 0.1 },
+            "HO2": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "MEKO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "MEKOOH": { "yield": 0.8 },
+            "OH": { "yield": 0.2 },
+            "CH3CHO": { "yield": 0.2 },
+            "CH3CO3": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.4e-12,
+          "Ea": 1.51871e-20,
+          "reactants": {
+            "SO": { },
+            "O3": { }
+          },
+          "products": {
+            "SO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "Ea": 2.66465e-21,
+          "reactants": {
+            "BENZENE": { },
+            "OH": { }
+          },
+          "products": {
+            "BENZENE": { },
+            "OH": { },
+            "BENZO2VBS": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.0e-14,
+          "reactants": {
+            "PAN": { },
+            "OH": { }
+          },
+          "products": {
+            "CH2O": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "TERPO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "TERPOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-12,
+          "reactants": {
+            "NO3": { },
+            "MCO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH2O": { },
+            "CH3CO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jn2o",
+          "reactants": {
+            "N2O": { }
+          },
+          "products": {
+            "O1D": { },
+            "N2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch2o_a",
+          "reactants": {
+            "CH2O": { }
+          },
+          "products": {
+            "CO": { },
+            "H": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-11,
+          "Ea": 2.7613e-21,
+          "reactants": {
+            "O3": { },
+            "CL": { }
+          },
+          "products": {
+            "CLO": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-11,
+          "Ea": -1.72581e-21,
+          "reactants": {
+            "NO3": { },
+            "NO": { }
+          },
+          "products": {
+            "NO2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "EO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "EOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.8e-13,
+          "Ea": 1.44968e-20,
+          "reactants": {
+            "CH3CN": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.04762e-5,
+          "k0_B": -3.4,
+          "k0_C": -10900,
+          "kinf_A": 1.90476e+15,
+          "kinf_B": -0.3,
+          "kinf_C": -10900,
+          "reactants": {
+            "HO2NO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhcfc22",
+          "reactants": {
+            "HCFC22": { }
+          },
+          "products": {
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-12,
+          "Ea": 1.29781e-20,
+          "reactants": {
+            "OH": { },
+            "O3": { }
+          },
+          "products": {
+            "HO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-13,
+          "Ea": 3.38259e-20,
+          "reactants": {
+            "O3": { },
+            "NO2": { }
+          },
+          "products": {
+            "NO3": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.05e-11,
+          "Ea": 3.13407e-20,
+          "reactants": {
+            "CL": { },
+            "H2": { }
+          },
+          "products": {
+            "HCL": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jnc4cho",
+          "reactants": {
+            "NC4CHO": { }
+          },
+          "products": {
+            "BIGALD3": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.5e-15,
+          "Ea": 2.62323e-20,
+          "reactants": {
+            "O3": { },
+            "C3H6": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.5 },
+            "HCOOH": { "yield": 0.12 },
+            "CH3COOH": { "yield": 0.12 },
+            "CH3CHO": { "yield": 0.5 },
+            "CO": { "yield": 0.56 },
+            "CH3O2": { "yield": 0.28 },
+            "CH4": { "yield": 0.1 },
+            "CO2": { "yield": 0.2 },
+            "HO2": { "yield": 0.28 },
+            "OH": { "yield": 0.36 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhonitr",
+          "reactants": {
+            "HONITR": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { "yield": 0.67 },
+            "CH3CHO": { "yield": 0.33 },
+            "CH2O": { "yield": 0.33 },
+            "CO": { "yield": 0.33 },
+            "GLYALD": { "yield": 0.33 },
+            "CH3CO3": { "yield": 0.33 },
+            "HYAC": { "yield": 0.17 },
+            "CH3COCH3": { "yield": 0.17 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "C6H5O2": { },
+            "NO": { }
+          },
+          "products": {
+            "PHENO": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jxooh",
+          "reactants": {
+            "XOOH": { }
+          },
+          "products": {
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "NO3": { },
+            "ISOPBO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HYDRALD": { "yield": 0.95 },
+            "HO2": { },
+            "GLYOXAL": { "yield": 0.05 },
+            "GLYALD": { "yield": 0.05 },
+            "CH3COCHO": { "yield": 0.05 },
+            "HYAC": { "yield": 0.05 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.26e-11,
+          "Ea": -2.7613e-22,
+          "reactants": {
+            "N2O": { },
+            "O1D": { }
+          },
+          "products": {
+            "NO": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-10,
+          "reactants": {
+            "OH": { },
+            "NC4CHO": { }
+          },
+          "products": {
+            "GLYOXAL": { },
+            "NOA": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch4_a",
+          "reactants": {
+            "CH4": { }
+          },
+          "products": {
+            "H": { },
+            "CH3O2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 5.2e-31,
+          "k0_B": -3.2,
+          "kinf_A": 6.9e-12,
+          "kinf_B": -2.9,
+          "reactants": {
+            "BRO": { },
+            "NO2": { }
+          },
+          "products": {
+            "BRONO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhobr",
+          "reactants": {
+            "HOBR": { }
+          },
+          "products": {
+            "BR": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.6e-29,
+          "k0_B": -3.3,
+          "kinf_A": 3.1e-10,
+          "kinf_B": -1.0,
+          "reactants": {
+            "C2H4": { },
+            "CL": { }
+          },
+          "products": {
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "NO": { },
+            "MTERPO2VBS": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.0245 },
+            "SOAG1": { "yield": 0.0082 },
+            "SOAG2": { "yield": 0.0772 },
+            "SOAG3": { "yield": 0.0332 },
+            "SOAG4": { "yield": 0.13 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "XYLEO2VBS": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.0063 },
+            "SOAG1": { "yield": 0.0237 },
+            "SOAG2": { "yield": 0.0025 },
+            "SOAG3": { "yield": 0.011 },
+            "SOAG4": { "yield": 0.1185 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jno3_a",
+          "reactants": {
+            "NO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2o_a",
+          "reactants": {
+            "H2O": { }
+          },
+          "products": {
+            "OH": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3co3h",
+          "reactants": {
+            "CH3COOOH": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "OH": { },
+            "CO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-11,
+          "Ea": -3.45162e-21,
+          "reactants": {
+            "OH": { },
+            "BRO": { }
+          },
+          "products": {
+            "BR": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.8e-12,
+          "Ea": -3.58969e-21,
+          "reactants": {
+            "NO": { },
+            "BRO": { }
+          },
+          "products": {
+            "BR": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-13,
+          "Ea": -6.35099e-21,
+          "reactants": {
+            "HO2": { "qty": 2 }
+          },
+          "products": {
+            "H2O2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.1e-33,
+          "Ea": -1.2702e-20,
+          "reactants": {
+            "HO2": { "qty": 2 },
+            "M": { }
+          },
+          "products": {
+            "H2O2": { },
+            "O2": { },
+            "M": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-34,
+          "Ea": -3.67253e-20,
+          "reactants": {
+            "HO2": { "qty": 2 },
+            "H2O": { }
+          },
+          "products": {
+            "H2O2": { },
+            "O2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.94e-54,
+          "Ea": -4.30762e-20,
+          "reactants": {
+            "HO2": { "qty": 2 },
+            "M": { },
+            "H2O": { }
+          },
+          "products": {
+            "H2O2": { },
+            "O2": { },
+            "M": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 6.9e-31,
+          "k0_B": -1,
+          "kinf_A": 2.6e-11,
+          "reactants": {
+            "OH": { "qty": 2 }
+          },
+          "products": {
+            "H2O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jonitr",
+          "reactants": {
+            "ONITR": { }
+          },
+          "products": {
+            "NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jterpooh",
+          "reactants": {
+            "TERPOOH": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.4 },
+            "CH3COCH3": { "yield": 0.05 },
+            "TERPROD1": { },
+            "HO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcl2",
+          "reactants": {
+            "CL2": { }
+          },
+          "products": {
+            "CL": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.6e-13,
+          "Ea": 1.59603e-20,
+          "reactants": {
+            "NO3": { },
+            "C3H6": { }
+          },
+          "products": {
+            "NOA": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-11,
+          "reactants": {
+            "BCARY": { },
+            "NO3": { }
+          },
+          "products": {
+            "NTERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-14,
+          "reactants": {
+            "BCARY": { },
+            "O3": { }
+          },
+          "products": {
+            "TERPROD1": { "yield": 0.33 },
+            "TERPROD2": { "yield": 0.3 },
+            "OH": { "yield": 0.63 },
+            "HO2": { "yield": 0.57 },
+            "CO": { "yield": 0.23 },
+            "CO2": { "yield": 0.27 },
+            "CH3COCH3": { "yield": 0.52 },
+            "CH2O": { "yield": 0.34 },
+            "BIGALD": { "yield": 0.1 },
+            "HCOOH": { "yield": 0.05 },
+            "BIGALK": { "yield": 0.05 },
+            "CH3CO3": { "yield": 0.06 },
+            "RO2": { "yield": 0.06 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.2e-13,
+          "Ea": 2.15381e-20,
+          "reactants": {
+            "OH": { },
+            "HCFC22": { }
+          },
+          "products": {
+            "H2O": { },
+            "CL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-10,
+          "reactants": {
+            "O3": { },
+            "O1D": { }
+          },
+          "products": {
+            "O2": { },
+            "O": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3cho",
+          "reactants": {
+            "CH3CHO": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "CO": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "C2H5OOH": { },
+            "OH": { }
+          },
+          "products": {
+            "C2H5O2": { "yield": 0.5 },
+            "CH3CHO": { "yield": 0.5 },
+            "OH": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.8e-14,
+          "reactants": {
+            "C2H5O2": { "qty": 2 }
+          },
+          "products": {
+            "CH3CHO": { "yield": 1.6 },
+            "HO2": { "yield": 1.2 },
+            "C2H5OH": { "yield": 0.4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-11,
+          "reactants": {
+            "OH": { },
+            "N": { }
+          },
+          "products": {
+            "NO": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "NO": { },
+            "XO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { },
+            "CO": { "yield": 0.25 },
+            "CH2O": { "yield": 0.25 },
+            "GLYOXAL": { "yield": 0.25 },
+            "CH3COCHO": { "yield": 0.25 },
+            "HYAC": { "yield": 0.25 },
+            "GLYALD": { "yield": 0.25 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.644e-11,
+          "reactants": {
+            "CFC115": { },
+            "O1D": { }
+          },
+          "products": {
+            "CL": { },
+            "F": { },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jbigald1",
+          "reactants": {
+            "BIGALD1": { }
+          },
+          "products": {
+            "MALO2": { "yield": 0.6 },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhno3",
+          "reactants": {
+            "HNO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "CH3CO3": { },
+            "HO2": { }
+          },
+          "products": {
+            "CH3COOOH": { "yield": 0.4 },
+            "CH3COOH": { "yield": 0.15 },
+            "O3": { "yield": 0.15 },
+            "OH": { "yield": 0.45 },
+            "CH3O2": { "yield": 0.45 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jc2h5ooh",
+          "reactants": {
+            "C2H5OOH": { }
+          },
+          "products": {
+            "CH3CHO": { },
+            "HO2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.7e-13,
+          "Ea": -1.68439e-20,
+          "reactants": {
+            "OH": { },
+            "PHENOL": { }
+          },
+          "products": {
+            "PHENO2": { "yield": 0.14 },
+            "HO2": { "yield": 0.8 },
+            "PHENO": { "yield": 0.06 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.08e-10,
+          "Ea": -1.44968e-21,
+          "reactants": {
+            "HCN": { },
+            "O1D": { }
+          },
+          "products": {
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.0e-11,
+          "reactants": {
+            "ISOPNOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "NOA": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.9e-12,
+          "Ea": -3.03743e-21,
+          "reactants": {
+            "N": { },
+            "NO2": { }
+          },
+          "products": {
+            "N2O": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jco2",
+          "reactants": {
+            "CO2": { }
+          },
+          "products": {
+            "CO": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.0e-11,
+          "reactants": {
+            "O1D": { },
+            "HBR": { }
+          },
+          "products": {
+            "BR": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.0e-12,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "HNO3": { },
+            "F": { }
+          },
+          "products": {
+            "HF": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcfc115",
+          "reactants": {
+            "CFC115": { }
+          },
+          "products": {
+            "CL": { },
+            "F": { },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.19e-12,
+          "Ea": 8.69809e-21,
+          "reactants": {
+            "OH": { },
+            "C3H8": { }
+          },
+          "products": {
+            "C3H7O2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhcfc141b",
+          "reactants": {
+            "HCFC141B": { }
+          },
+          "products": {
+            "CL": { },
+            "COFCL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.5e-11,
+          "reactants": {
+            "CH4": { },
+            "O1D": { }
+          },
+          "products": {
+            "CH2O": { },
+            "H": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jterprd1",
+          "reactants": {
+            "TERPROD1": { }
+          },
+          "products": {
+            "HO2": { },
+            "CO": { },
+            "TERPROD2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jmpan",
+          "reactants": {
+            "MPAN": { }
+          },
+          "products": {
+            "MCO3": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jclono2_a",
+          "reactants": {
+            "CLONO2": { }
+          },
+          "products": {
+            "CL": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-11,
+          "Ea": 4.55614e-20,
+          "reactants": {
+            "HCL": { },
+            "O": { }
+          },
+          "products": {
+            "CL": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.0e-13,
+          "reactants": {
+            "HCOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "HO2": { },
+            "CO2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-11,
+          "Ea": 1.10452e-20,
+          "reactants": {
+            "BR": { },
+            "CH2O": { }
+          },
+          "products": {
+            "HBR": { },
+            "HO2": { },
+            "CO": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa3_a1",
+          "reactants": {
+            "soa3_a1": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa4_a2",
+          "reactants": {
+            "soa4_a2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.5e-12,
+          "Ea": -6.35099e-21,
+          "reactants": {
+            "BRO": { },
+            "HO2": { }
+          },
+          "products": {
+            "HOBR": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.1e-13,
+          "Ea": -1.03549e-20,
+          "reactants": {
+            "CH3O2": { },
+            "HO2": { }
+          },
+          "products": {
+            "CH3OOH": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.7e-12,
+          "Ea": -4.97034e-21,
+          "reactants": {
+            "ISOPNO3": { },
+            "NO": { }
+          },
+          "products": {
+            "NC4CHO": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcf3br",
+          "reactants": {
+            "CF3BR": { }
+          },
+          "products": {
+            "BR": { },
+            "F": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.76e-34,
+          "Ea": -9.94067e-21,
+          "reactants": {
+            "O": { "qty": 2 },
+            "M": { }
+          },
+          "products": {
+            "O2": { },
+            "M": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.3e-16,
+          "Ea": 8.00776e-21,
+          "reactants": {
+            "O3": { },
+            "MTERP": { }
+          },
+          "products": {
+            "TERPROD1": { "yield": 0.33 },
+            "TERPROD2": { "yield": 0.3 },
+            "OH": { "yield": 0.63 },
+            "HO2": { "yield": 0.57 },
+            "CO": { "yield": 0.23 },
+            "CO2": { "yield": 0.27 },
+            "CH3COCH3": { "yield": 0.52 },
+            "CH2O": { "yield": 0.34 },
+            "BIGALD": { "yield": 0.1 },
+            "HCOOH": { "yield": 0.05 },
+            "BIGALK": { "yield": 0.05 },
+            "CH3CO3": { "yield": 0.06 },
+            "RO2": { "yield": 0.06 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.1e-11,
+          "Ea": 1.35304e-20,
+          "reactants": {
+            "CL": { },
+            "H2O2": { }
+          },
+          "products": {
+            "HCL": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.7e-13,
+          "reactants": {
+            "OH": { },
+            "NOA": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH3COCHO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.2e-14,
+          "Ea": 1.47729e-20,
+          "reactants": {
+            "OH": { },
+            "OCS": { }
+          },
+          "products": {
+            "SO2": { },
+            "CO": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.3e-11,
+          "reactants": {
+            "OH": { },
+            "TERPOOH": { }
+          },
+          "products": {
+            "TERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.5e-12,
+          "reactants": {
+            "BIGALK": { },
+            "OH": { }
+          },
+          "products": {
+            "ALKO2": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 9.7e-29,
+          "k0_B": -5.6,
+          "kinf_A": 9.3e-12,
+          "kinf_B": -1.5,
+          "reactants": {
+            "DICARBO2": { },
+            "NO2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-11,
+          "Ea": 1.07691e-20,
+          "reactants": {
+            "BR": { },
+            "O3": { }
+          },
+          "products": {
+            "BRO": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-12,
+          "Ea": 2.66465e-21,
+          "reactants": {
+            "BENZENE": { },
+            "OH": { }
+          },
+          "products": {
+            "PHENOL": { "yield": 0.53 },
+            "BEPOMUC": { "yield": 0.12 },
+            "HO2": { "yield": 0.65 },
+            "BENZO2": { "yield": 0.35 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3cl",
+          "reactants": {
+            "CH3CL": { }
+          },
+          "products": {
+            "CL": { },
+            "CH3O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhcl",
+          "reactants": {
+            "HCL": { }
+          },
+          "products": {
+            "H": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": -5.5226e-21,
+          "reactants": {
+            "CH3O2": { },
+            "MACRO2": { }
+          },
+          "products": {
+            "HO2": { "yield": 0.73 },
+            "CH2O": { "yield": 0.88 },
+            "CO": { "yield": 0.11 },
+            "CH3COCHO": { "yield": 0.24 },
+            "GLYALD": { "yield": 0.26 },
+            "CH3CO3": { "yield": 0.26 },
+            "CH3OH": { "yield": 0.25 },
+            "HYAC": { "yield": 0.23 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.0e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "ISOPAO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "ISOPOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.5e-41,
+          "C": 6540,
+          "reactants": {
+            "H2O": { "qty": 2 },
+            "SO3": {}
+          },
+          "products": {
+            "H2SO4": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jtolooh",
+          "reactants": {
+            "TOLOOH": { }
+          },
+          "products": {
+            "OH": { },
+            "GLYOXAL": { "yield": 0.6 },
+            "CH3COCHO": { "yield": 0.4 },
+            "HO2": { },
+            "BIGALD1": { "yield": 0.2 },
+            "BIGALD2": { "yield": 0.2 },
+            "BIGALD3": { "yield": 0.2 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3ccl3",
+          "reactants": {
+            "CH3CCL3": { }
+          },
+          "products": {
+            "CL": { "yield": 3 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-11,
+          "reactants": {
+            "NTERPOOH": { },
+            "OH": { }
+          },
+          "products": {
+            "NTERPO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.8e-12,
+          "Ea": -4.14195e-21,
+          "reactants": {
+            "CH3O2": { },
+            "NO": { }
+          },
+          "products": {
+            "CH2O": { },
+            "NO2": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "ISOPAO2": { },
+            "NO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "MACR": { "yield": 0.4 },
+            "MVK": { "yield": 0.6 },
+            "CH2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "BZOO": { },
+            "HO2": { }
+          },
+          "products": {
+            "BZOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "TOLUO2VBS": { }
+          },
+          "products": {
+            "NO": { },
+            "SOAG0": { "yield": 0.0154 },
+            "SOAG1": { "yield": 0.0452 },
+            "SOAG2": { "yield": 0.0966 },
+            "SOAG3": { "yield": 0.0073 },
+            "SOAG4": { "yield": 0.238 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-13,
+          "Ea": -1.79484e-20,
+          "reactants": {
+            "MTERPO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.0508 },
+            "SOAG1": { "yield": 0.1149 },
+            "SOAG2": { "yield": 0.0348 },
+            "SOAG3": { "yield": 0.0554 },
+            "SOAG4": { "yield": 0.1278 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.2e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "NO": { },
+            "MEKO2": { }
+          },
+          "products": {
+            "CH3CO3": { },
+            "CH3CHO": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "XYLENO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "XYLENOOH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa2_a1",
+          "reactants": {
+            "soa2_a1": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-12,
+          "Ea": -4.00388e-21,
+          "reactants": {
+            "NO": { },
+            "DICARBO2": { }
+          },
+          "products": {
+            "NO2": { },
+            "HO2": { "yield": 0.17 },
+            "CH3COCHO": { "yield": 0.17 },
+            "CO": { "yield": 0.17 },
+            "CH3O2": { "yield": 0.83 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jglyald",
+          "reactants": {
+            "GLYALD": { }
+          },
+          "products": {
+            "HO2": { "yield": 2 },
+            "CO": { },
+            "CH2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "TERP2O2": { },
+            "HO2": { }
+          },
+          "products": {
+            "TERP2OOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.3e-12,
+          "reactants": {
+            "HCL": { },
+            "O1D": { }
+          },
+          "products": {
+            "CLO": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jocs",
+          "reactants": {
+            "OCS": { }
+          },
+          "products": {
+            "S": { },
+            "CO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.2e-14,
+          "reactants": {
+            "BCARY": { },
+            "O3": { }
+          },
+          "products": {
+            "BCARY": { },
+            "O3": { },
+            "SOAG0": { "yield": 0.2202 },
+            "SOAG1": { "yield": 0.2067 },
+            "SOAG2": { "yield": 0.0653 },
+            "SOAG3": { "yield": 0.1284 },
+            "SOAG4": { "yield": 0.114 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsf6",
+          "reactants": {
+            "SF6": { }
+          },
+          "products": {
+            "sink": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.1e-13,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "CH3O2": { },
+            "RO2": { }
+          },
+          "products": {
+            "CH3CO3": { "yield": 0.3 },
+            "CH2O": { "yield": 0.8 },
+            "HO2": { "yield": 0.3 },
+            "HYAC": { "yield": 0.2 },
+            "CH3COCHO": { "yield": 0.5 },
+            "CH3OH": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "XYLOLO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "XYLOLOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-11,
+          "reactants": {
+            "BCARY": { },
+            "NO3": { }
+          },
+          "products": {
+            "BCARY": { },
+            "NO3": { },
+            "SOAG3": { "yield": 0.17493 },
+            "SOAG4": { "yield": 0.59019 }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jhocl",
+          "reactants": {
+            "HOCL": { }
+          },
+          "products": {
+            "OH": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.607e-10,
+          "reactants": {
+            "O1D": { },
+            "CCL4": { }
+          },
+          "products": {
+            "CL": { "yield": 4 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.3e-13,
+          "Ea": -1.43587e-20,
+          "reactants": {
+            "DICARBO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { "yield": 0.4 },
+            "HO2": { "yield": 0.07 },
+            "CH3COCHO": { "yield": 0.07 },
+            "CO": { "yield": 0.07 },
+            "CH3O2": { "yield": 0.33 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.8e-12,
+          "Ea": -2.7613e-21,
+          "reactants": {
+            "OH": { },
+            "ROOH": { }
+          },
+          "products": {
+            "RO2": { },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e+11,
+          "Ea": 5.72969e-20,
+          "reactants": {
+            "EO": { }
+          },
+          "products": {
+            "CH2O": { "yield": 2 },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.05e-14,
+          "Ea": 2.7613e-20,
+          "reactants": {
+            "ISOP": { },
+            "O3": { }
+          },
+          "products": {
+            "MACR": { "yield": 0.3 },
+            "MVK": { "yield": 0.2 },
+            "HCOOH": { "yield": 0.11 },
+            "CO": { "yield": 0.62 },
+            "OH": { "yield": 0.32 },
+            "HO2": { "yield": 0.37 },
+            "CH2O": { "yield": 0.91 },
+            "CH3CO3": { "yield": 0.08 },
+            "C3H6": { "yield": 0.13 },
+            "CH3O2": { "yield": 0.05 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.1e-14,
+          "Ea": -9.5679e-21,
+          "reactants": {
+            "NO": { },
+            "ENEO2": { }
+          },
+          "products": {
+            "HONITR": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jch3ooh",
+          "reactants": {
+            "CH3OOH": { }
+          },
+          "products": {
+            "CH2O": { },
+            "H": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jclo",
+          "reactants": {
+            "CLO": { }
+          },
+          "products": {
+            "CL": { },
+            "O": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcofcl",
+          "reactants": {
+            "COFCL": { }
+          },
+          "products": {
+            "F": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.03e-12,
+          "Ea": 6.15769e-21,
+          "reactants": {
+            "ISOP": { },
+            "NO3": { }
+          },
+          "products": {
+            "ISOPNO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.31e-10,
+          "reactants": {
+            "CH4": { },
+            "O1D": { }
+          },
+          "products": {
+            "CH3O2": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.5e-13,
+          "reactants": {
+            "BIGENE": { },
+            "NO3": { }
+          },
+          "products": {
+            "NO2": { },
+            "CH3CHO": { },
+            "CH2O": { "yield": 0.5 },
+            "CH3COCH3": { "yield": 0.5 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.4e-12,
+          "reactants": {
+            "NO3": { },
+            "NTERPO2": { }
+          },
+          "products": {
+            "NO2": { "yield": 2 },
+            "TERPROD1": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.34e-8,
+          "reactants": {
+            "NH4": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e+9,
+          "Ea": 1.14594e-19,
+          "reactants": {
+            "ISOPBO2": { }
+          },
+          "products": {
+            "HPALD": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "BENZO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "BENZOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-12,
+          "reactants": {
+            "OH": { },
+            "ALKNIT": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.4 },
+            "CH3CHO": { "yield": 0.8 },
+            "CH3COCH3": { "yield": 0.8 },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.46e-11,
+          "Ea": 1.43587e-20,
+          "reactants": {
+            "CH3BR": { },
+            "CL": { }
+          },
+          "products": {
+            "HCL": { },
+            "HO2": { },
+            "BR": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.4e-11,
+          "reactants": {
+            "OH": { },
+            "TERPROD2": { }
+          },
+          "products": {
+            "RO2": { "yield": 0.15 },
+            "CH2O": { "yield": 0.68 },
+            "CO2": { "yield": 1.8 },
+            "CH3COCH3": { "yield": 0.5 },
+            "CH3CO3": { "yield": 0.65 },
+            "HO2": { "yield": 0.2 },
+            "CO": { "yield": 0.7 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.6e-12,
+          "Ea": -5.03937e-21,
+          "reactants": {
+            "NO": { },
+            "XYLOLO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "NO2": { },
+            "GLYOXAL": { "yield": 0.17 },
+            "CH3COCHO": { "yield": 0.51 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.86e-11,
+          "Ea": -2.41614e-21,
+          "reactants": {
+            "OH": { },
+            "HYDRALD": { }
+          },
+          "products": {
+            "XO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": -6.90325e-21,
+          "reactants": {
+            "TERP2O2": { },
+            "CH3O2": { }
+          },
+          "products": {
+            "TERPROD2": { },
+            "CH2O": { "yield": 0.93 },
+            "CH3OH": { "yield": 0.25 },
+            "HO2": { },
+            "CO2": { "yield": 0.5 },
+            "CO": { "yield": 0.125 },
+            "GLYALD": { "yield": 0.125 },
+            "CH3COCH3": { "yield": 0.15 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.5e-12,
+          "Ea": -1.72581e-21,
+          "reactants": {
+            "OH": { },
+            "CH2O": { }
+          },
+          "products": {
+            "CO": { },
+            "H2O": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-11,
+          "Ea": -2.9684e-21,
+          "reactants": {
+            "O": { },
+            "BRONO2": { }
+          },
+          "products": {
+            "BRO": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.5e-16,
+          "Ea": 2.09859e-20,
+          "reactants": {
+            "O3": { },
+            "MVK": { }
+          },
+          "products": {
+            "CH2O": { "yield": 0.6 },
+            "CO": { "yield": 0.56 },
+            "CH3CHO": { "yield": 0.1 },
+            "CO2": { "yield": 0.1 },
+            "CH3CO3": { "yield": 0.28 },
+            "CH3COCHO": { "yield": 0.5 },
+            "HO2": { "yield": 0.28 },
+            "OH": { "yield": 0.36 },
+            "HCOOH": { "yield": 0.12 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 8.1e-11,
+          "Ea": 4.14195e-22,
+          "reactants": {
+            "CL": { },
+            "CH2O": { }
+          },
+          "products": {
+            "HCL": { },
+            "HO2": { },
+            "CO": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jo2_a",
+          "reactants": {
+            "O2": { }
+          },
+          "products": {
+            "O": { },
+            "O1D": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.0e-13,
+          "Ea": 5.85395e-21,
+          "reactants": {
+            "CH3O2": { "qty": 2 }
+          },
+          "products": {
+            "CH2O": { "yield": 2 },
+            "HO2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-12,
+          "Ea": -4.85988e-21,
+          "reactants": {
+            "TOLUENE": { },
+            "OH": { }
+          },
+          "products": {
+            "CRESOL": { "yield": 0.18 },
+            "TEPOMUC": { "yield": 0.1 },
+            "BZOO": { "yield": 0.07 },
+            "TOLO2": { "yield": 0.65 },
+            "HO2": { "yield": 0.28 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.0e-12,
+          "Ea": 2.19523e-20,
+          "reactants": {
+            "CLO": { "qty": 2 }
+          },
+          "products": {
+            "CL2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "IVOCO2VBS": { },
+            "HO2": { }
+          },
+          "products": {
+            "HO2": { },
+            "SOAG0": { "yield": 0.2381 },
+            "SOAG1": { "yield": 0.1308 },
+            "SOAG2": { "yield": 0.0348 },
+            "SOAG3": { "yield": 0.0076 },
+            "SOAG4": { "yield": 0.0113 }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 1.07767,
+          "k0_B": -5.6,
+          "k0_C": -14000,
+          "kinf_A": 1.03323e+17,
+          "kinf_B": -1.5,
+          "kinf_C": -14000,
+          "reactants": {
+            "MPAN": { }
+          },
+          "products": {
+            "MCO3": { },
+            "NO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.0e-12,
+          "Ea": 2.07097e-20,
+          "reactants": {
+            "NO": { },
+            "O3": { }
+          },
+          "products": {
+            "NO2": { },
+            "O2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jh2402",
+          "reactants": {
+            "H2402": { }
+          },
+          "products": {
+            "BR": { "yield": 2 },
+            "COF2": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.3e-11,
+          "reactants": {
+            "TERP2OOH": { },
+            "OH": { }
+          },
+          "products": {
+            "TERP2O2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 9.5e-13,
+          "Ea": -7.59357e-21,
+          "reactants": {
+            "BRO": { },
+            "CLO": { }
+          },
+          "products": {
+            "BR": { },
+            "OCLO": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.0e-12,
+          "Ea": 1.15975e-20,
+          "reactants": {
+            "CH2BR2": { },
+            "OH": { }
+          },
+          "products": {
+            "BR": { "yield": 2 },
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.8e-12,
+          "reactants": {
+            "OH": { },
+            "H2O2": { }
+          },
+          "products": {
+            "H2O": { },
+            "HO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.2e-11,
+          "reactants": {
+            "H": { },
+            "HO2": { }
+          },
+          "products": {
+            "OH": { "yield": 2 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.8e-12,
+          "Ea": 3.45162e-21,
+          "reactants": {
+            "HCL": { },
+            "OH": { }
+          },
+          "products": {
+            "H2O": { },
+            "CL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 2.088e-10,
+          "reactants": {
+            "CFC113": { },
+            "O1D": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COFCL": { },
+            "COF2": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jsoa1_a2",
+          "reactants": {
+            "soa1_a2": { }
+          },
+          "products": {
+
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.9e-14,
+          "Ea": -9.74738e-21,
+          "reactants": {
+            "CH3O2": { "qty": 2 }
+          },
+          "products": {
+            "CH2O": { },
+            "CH3OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.4e-10,
+          "Ea": 6.90325e-21,
+          "reactants": {
+            "F": { },
+            "H2": { }
+          },
+          "products": {
+            "HF": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.7e-12,
+          "Ea": 9.80261e-21,
+          "reactants": {
+            "NH3": { },
+            "OH": { }
+          },
+          "products": {
+            "H2O": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.85e-12,
+          "Ea": 1.17355e-20,
+          "reactants": {
+            "CHBR3": { },
+            "CL": { }
+          },
+          "products": {
+            "BR": { "yield": 3 },
+            "HCL": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 3.6e-12,
+          "Ea": 1.15975e-20,
+          "reactants": {
+            "CLONO2": { },
+            "O": { }
+          },
+          "products": {
+            "CLO": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 4.4e-12,
+          "Ea": -2.48517e-21,
+          "reactants": {
+            "ISOPAO2": { },
+            "NO": { }
+          },
+          "products": {
+            "ISOPNITA": { "yield": 0.08 },
+            "NO2": { "yield": 0.92 },
+            "MACR": { "yield": 0.36 },
+            "MVK": { "yield": 0.56 },
+            "CH2O": { "yield": 0.92 },
+            "HO2": { "yield": 0.92 }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 1.6e-11,
+          "Ea": 6.30957e-20,
+          "reactants": {
+            "O": { },
+            "H2": { }
+          },
+          "products": {
+            "OH": { },
+            "H": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 2.5e-31,
+          "k0_B": -1.8,
+          "kinf_A": 2.2e-11,
+          "kinf_B": -0.7,
+          "reactants": {
+            "NO2": { },
+            "O": { }
+          },
+          "products": {
+            "NO3": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.8e-12,
+          "Ea": 2.07097e-20,
+          "reactants": {
+            "O": { },
+            "HBR": { }
+          },
+          "products": {
+            "BR": { },
+            "OH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 5.4e-11,
+          "reactants": {
+            "BIGENE": { },
+            "OH": { }
+          },
+          "products": {
+            "ENEO2": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 7.5e-13,
+          "Ea": -9.66454e-21,
+          "reactants": {
+            "TOLO2": { },
+            "HO2": { }
+          },
+          "products": {
+            "TOLOOH": { }
+          }
+        },
+        {
+          "type": "ARRHENIUS",
+          "A": 6.5e-12,
+          "Ea": -1.86388e-21,
+          "reactants": {
+            "CLONO2": { },
+            "CL": { }
+          },
+          "products": {
+            "CL2": { },
+            "NO3": { }
+          }
+        },
+        {
+          "type": "TROE",
+          "k0_A": 2.4e-30,
+          "k0_B": -3,
+          "kinf_A": 1.6e-12,
+          "kinf_B": 0.1,
+          "reactants": {
+            "NO3": { },
+            "NO2": { }
+          },
+          "products": {
+            "N2O5": { }
+          }
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "MUSICA name": "jcfcl3",
+          "reactants": {
+            "CFC11": { }
+          },
+          "products": {
+            "CL": { "yield": 2 },
+            "COFCL": { }
+          }
+        }
+      ]
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_HO2_aer",
+      "reaction probability": 0.02,
+      "gas-phase reactant": "HO2",
+      "gas-phase products": {
+        "H2O": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_NO3_aer",
+      "reaction probability": 0.002,
+      "gas-phase reactant": "NO3",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_ISOPNITA_aer",
+      "reaction probability": 0.005,
+      "gas-phase reactant": "ISOPNITA",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_ISOPNITB_aer",
+      "reaction probability": 0.005,
+      "gas-phase reactant": "ISOPNITB",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_GLYOXAL_aer",
+      "reaction probability": 2.0e-4,
+      "gas-phase reactant": "GLYOXAL",
+      "gas-phase products": {
+        "SOAG0": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_ONITR_aer",
+      "reaction probability": 0.005,
+      "gas-phase reactant": "ONITR",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_N2O5_aer",
+      "reaction probability": 0.02,
+      "gas-phase reactant": "N2O5",
+      "gas-phase products": {
+        "HNO3": { "yield": 2 }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_HONITR_aer",
+      "reaction probability": 0.005,
+      "gas-phase reactant": "HONITR",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_NC4CHO_aer",
+      "reaction probability": 0.02,
+      "gas-phase reactant": "NC4CHO",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_TERPNIT_aer",
+      "reaction probability": 0.01,
+      "gas-phase reactant": "TERPNIT",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_NTERPOOH_aer",
+      "reaction probability": 0.01,
+      "gas-phase reactant": "NTERPOOH",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_NC4CH2OH_aer",
+      "reaction probability": 0.005,
+      "gas-phase reactant": "NC4CH2OH",
+      "gas-phase products": {
+        "HNO3": { }
+      }
+    },
+    {
+      "type": "SURFACE",
+      "MUSICA name": "usr_NO2_aer",
+      "reaction probability": 8.0e-6,
+      "gas-phase reactant": "NO2",
+      "gas-phase products": {
+        "OH": { "yield": 0.5 },
+        "NO": { "yield": 0.5 },
+        "HNO3": { "yield": 0.5 }
+      }
+    },
+    {
+      "type": "ARRHENIUS",
+      "reactants": {
+        "OH": { },
+        "CO": { }
+      },
+      "products": {
+        "CO2": { },
+        "HO2": { }
+      },
+      "A": 1.5e-13,
+      "B": 0,
+      "C": 0,
+      "E": 0
+    },
+    {
+      "type": "ARRHENIUS",
+      "reactants": {
+        "OH": { },
+        "CO": { },
+        "M": { }
+      },
+      "products": {
+        "CO2": { },
+        "HO2": { }
+      },
+      "A": 9.0e-20,
+      "B": 1,
+      "C": 0,
+      "D": 1,
+      "E": 0
+    },
+    {
+      "type": "TROE",
+      "reactants": {
+           "OH": {},
+           "DMS": {}
+       },
+       "products": {
+           "SO2": {
+               "yield": 0.5
+           },
+           "HO2": {
+               "yield": 0.5
+           }
+       },
+       "k0_A": 3.57e-43,
+       "k0_B": 0.0,
+       "k0_C": 7810.0,
+       "kinf_A": 6.4909e-13,
+       "kinf_B": 0.0,
+       "kinf_C": 350.0,
+       "Fc": 1.0
+   }
+  ]
+}

--- a/src/acom_music_box/examples/configs/ts1/camp_data/species.json
+++ b/src/acom_music_box/examples/configs/ts1/camp_data/species.json
@@ -1,0 +1,1281 @@
+{
+  "camp-data": [
+    {
+      "type": "RELATIVE_TOLERANCE",
+      "value": 1.0e-4
+    },
+    {
+      "name": "ALKNIT",
+      "type": "CHEM_SPEC",
+      "__description": "standard alkyl nitrate from BIGALK+OH chemistry",
+      "molecular weight [kg mol-1]": 0.133141
+    },
+    {
+      "name": "BZOOH",
+      "type": "CHEM_SPEC",
+      "__description": "hydroperoxide from toluene oxidation",
+      "molecular weight [kg mol-1]": 0.124135
+    },
+    {
+      "name": "C6H5OOH",
+      "type": "CHEM_SPEC",
+      "__description": "phenyl hydroperoxide",
+      "molecular weight [kg mol-1]": 0.110109
+    },
+    {
+      "name": "COF2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "O2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "COFCL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "HF",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "F",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "BENZO2",
+      "type": "CHEM_SPEC",
+      "__description": "bicyclic peroxy radical from OH + benzene",
+      "molecular weight [kg mol-1]": 0.159115
+    },
+    {
+      "name": "BZOO",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy radical from toluene oxidation",
+      "molecular weight [kg mol-1]": 0.123128
+    },
+    {
+      "name": "N2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "E90",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "NH_5",
+      "type": "CHEM_SPEC",
+      "__description": "idealized tracer with 5 day loss rate",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "NH_50",
+      "type": "CHEM_SPEC",
+      "__description": "idealized tracer with 50-day loss rate",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "ST80_25",
+      "type": "CHEM_SPEC",
+      "__description": "Stratospheric loss tracer",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "PAN",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy acetyl nitrate",
+      "molecular weight [kg mol-1]": 0.121048
+    },
+    {
+      "name": "MVK",
+      "type": "CHEM_SPEC",
+      "__description": "methyl vinyl ketone",
+      "molecular weight [kg mol-1]": 0.0700878
+    },
+    {
+      "name": "MACROOH",
+      "type": "CHEM_SPEC",
+      "__description": "peroxide from methacrolein",
+      "molecular weight [kg mol-1]": 0.120101
+    },
+    {
+      "name": "SOAG0",
+      "type": "CHEM_SPEC",
+      "__description": "SOA gas-phase precursor VBS bin 0",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SOAG1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA gas-phase precursor VBS bin 1",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SOAG2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA gas-phase precursor VBS bin 2",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SOAG3",
+      "type": "CHEM_SPEC",
+      "__description": "SOA gas-phase precursor VBS bin 3",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SOAG4",
+      "type": "CHEM_SPEC",
+      "__description": "SOA gas-phase precursor VBS bin 4",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa4_a1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 4, MAM accumulation mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa5_a1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 5, MAM accumulation mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa5_a2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 5, MAM Aitken mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa3_a1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 3, MAM accumulation mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa2_a1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 2, MAM accumulation mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa1_a1",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 1, MAM accumulation mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa1_a2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 1, MAM Aitken mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa2_a2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 2, MAM Aitken mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa3_a2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 3, MAM Aitken mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "soa4_a2",
+      "type": "CHEM_SPEC",
+      "__description": "SOA bin 4, MAM Aitken mode",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "ISOPNITB",
+      "type": "CHEM_SPEC",
+      "__description": "1,4-hydroxynitrate from OH+isoprene chemistry",
+      "molecular weight [kg mol-1]": 0.147126,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "SO3",
+      "type": "CHEM_SPEC",
+      "__description": "sulfur trioxide",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "OCS",
+      "type": "CHEM_SPEC",
+      "__description": "carbonyl sulfide",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SO",
+      "type": "CHEM_SPEC",
+      "__description": "sulfur monoxide",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "S",
+      "type": "CHEM_SPEC",
+      "__description": "atomic sulfur",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "BCARYO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "BCARY oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "SF6",
+      "type": "CHEM_SPEC",
+      "__description": "sulfur hexafluoride",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "sink",
+      "type": "CHEM_SPEC",
+      "__description": "sink for sulfur hexaflouride",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "H",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0010074
+    },
+    {
+      "name": "MEK",
+      "type": "CHEM_SPEC",
+      "__description": "methyl ethyl ketone",
+      "molecular weight [kg mol-1]": 0.0721026
+    },
+    {
+      "name": "MTERP",
+      "type": "CHEM_SPEC",
+      "__description": "lumped monoterpenes",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "N2O5",
+      "type": "CHEM_SPEC",
+      "__description": "dinitrogen pentoxide",
+      "molecular weight [kg mol-1]": 0.10801,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "HCN",
+      "type": "CHEM_SPEC",
+      "__description": "hydrogen cyanide",
+      "molecular weight [kg mol-1]": 0.0270251
+    },
+    {
+      "name": "SVOC",
+      "type": "CHEM_SPEC",
+      "__description": "semi-volatile organic precursor of VBS SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "ISOPNO3",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy radical from isoprene NO3 oxidation",
+      "molecular weight [kg mol-1]": 0.162118
+    },
+    {
+      "name": "RO2",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy radical from acetone",
+      "molecular weight [kg mol-1]": 0.0890682
+    },
+    {
+      "name": "PHENO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.175114
+    },
+    {
+      "name": "BENZO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "benzene oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "IVOC",
+      "type": "CHEM_SPEC",
+      "__description": "intermediate volatility organic precursor of VBS SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "TERPNIT",
+      "type": "CHEM_SPEC",
+      "__description": "mostly hydroxynitrates from OH+terpene chemistry",
+      "molecular weight [kg mol-1]": 0.21524,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "ISOPO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "isoprene oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "IVOCO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "IVOC oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "HNO3",
+      "type": "CHEM_SPEC",
+      "__description": "nitric acid",
+      "molecular weight [kg mol-1]": 0.0630123
+    },
+    {
+      "name": "ACBZO2",
+      "type": "CHEM_SPEC",
+      "__description": "acylperoxy radical from benzaldehyde",
+      "molecular weight [kg mol-1]": 0.137112
+    },
+    {
+      "name": "CH3COOOH",
+      "type": "CHEM_SPEC",
+      "__description": "peracetic acid",
+      "molecular weight [kg mol-1]": 0.0760498
+    },
+    {
+      "name": "SO2",
+      "type": "CHEM_SPEC",
+      "__description": "sulfur dioxide",
+      "molecular weight [kg mol-1]": 0.0640648
+    },
+    {
+      "name": "MTERPO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "MTERP oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "CH4",
+      "type": "CHEM_SPEC",
+      "__description": "methane",
+      "molecular weight [kg mol-1]": 0.0160406
+    },
+    {
+      "name": "CH3CL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0504859
+    },
+    {
+      "name": "CH3CO3",
+      "type": "CHEM_SPEC",
+      "__description": "acetylperoxy radical",
+      "molecular weight [kg mol-1]": 0.0750424
+    },
+    {
+      "name": "C6H5O2",
+      "type": "CHEM_SPEC",
+      "__description": "phenylperoxy radical",
+      "molecular weight [kg mol-1]": 0.109102
+    },
+    {
+      "name": "TERPROD1",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.168227
+    },
+    {
+      "name": "HYAC",
+      "type": "CHEM_SPEC",
+      "__description": "hydroxyacetone",
+      "molecular weight [kg mol-1]": 0.0740762
+    },
+    {
+      "name": "HPALD",
+      "type": "CHEM_SPEC",
+      "__description": "hydroperoxyaldehyde",
+      "molecular weight [kg mol-1]": 0.116112
+    },
+    {
+      "name": "TOLUO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "toluene oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "H2O",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0180142
+    },
+    {
+      "name": "NO2",
+      "type": "CHEM_SPEC",
+      "__description": "nitrogen dioxide",
+      "molecular weight [kg mol-1]": 0.0460055,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "EOOH",
+      "type": "CHEM_SPEC",
+      "__description": "hydroxyhydroperoxide from OH + ethene chemistry",
+      "molecular weight [kg mol-1]": 0.0780646
+    },
+    {
+      "name": "NTERPOOH",
+      "type": "CHEM_SPEC",
+      "__description": "nitrooxy-hydroperoxide from NO3+terpene chemistry",
+      "molecular weight [kg mol-1]": 0.23124,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "XYLEO2VBS",
+      "type": "CHEM_SPEC",
+      "__description": "xylenes oxidation proxy for NOx-dependent VBS-SOA",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "CCL4",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.153822
+    },
+    {
+      "name": "CF2CLBR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.165365
+    },
+    {
+      "name": "CF3BR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.14891
+    },
+    {
+      "name": "CFC11",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.137368
+    },
+    {
+      "name": "CFC113",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.187375
+    },
+    {
+      "name": "CFC114",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.170921
+    },
+    {
+      "name": "CFC115",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.154467
+    },
+    {
+      "name": "CFC12",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.120913
+    },
+    {
+      "name": "CH2BR2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.173834
+    },
+    {
+      "name": "CH3BR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0949372
+    },
+    {
+      "name": "CH3CCL3",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.133402
+    },
+    {
+      "name": "NO",
+      "type": "CHEM_SPEC",
+      "__description": "nitric oxide",
+      "molecular weight [kg mol-1]": 0.0300061
+    },
+    {
+      "name": "BR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.079904
+    },
+    {
+      "name": "BRCL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.115357
+    },
+    {
+      "name": "BRO",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0959034
+    },
+    {
+      "name": "BRONO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.141909
+    },
+    {
+      "name": "CL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0354527
+    },
+    {
+      "name": "CL2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0709054
+    },
+    {
+      "name": "CL2O2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.102904
+    },
+    {
+      "name": "CLO",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0514521
+    },
+    {
+      "name": "CLONO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0974576
+    },
+    {
+      "name": "HCOOH",
+      "type": "CHEM_SPEC",
+      "__description": "formic acid",
+      "molecular weight [kg mol-1]": 0.0460246
+    },
+    {
+      "name": "HBR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0809114
+    },
+    {
+      "name": "HOBR",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0969108
+    },
+    {
+      "name": "HOCL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0524595
+    },
+    {
+      "name": "N",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0140067
+    },
+    {
+      "name": "BIGENE",
+      "type": "CHEM_SPEC",
+      "__description": "lumped alkenes C>3",
+      "molecular weight [kg mol-1]": 0.0561032
+    },
+    {
+      "name": "C2H4",
+      "type": "CHEM_SPEC",
+      "__description": "ethene",
+      "molecular weight [kg mol-1]": 0.0280516
+    },
+    {
+      "name": "C2H5O2",
+      "type": "CHEM_SPEC",
+      "__description": "ethylperoxy radical",
+      "molecular weight [kg mol-1]": 0.0610578
+    },
+    {
+      "name": "CH3COCHO",
+      "type": "CHEM_SPEC",
+      "__description": "methyl glyoxal",
+      "molecular weight [kg mol-1]": 0.0720614
+    },
+    {
+      "name": "CH3COCH3",
+      "type": "CHEM_SPEC",
+      "__description": "acetone",
+      "molecular weight [kg mol-1]": 0.0580768
+    },
+    {
+      "name": "O",
+      "type": "CHEM_SPEC",
+      "__description": "ground state atomic oxygen",
+      "molecular weight [kg mol-1]": 0.0159994
+    },
+    {
+      "name": "OCLO",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0674515
+    },
+    {
+      "name": "O1D",
+      "type": "CHEM_SPEC",
+      "__description": "excited state atomic oxygen",
+      "molecular weight [kg mol-1]": 0.0159994
+    },
+    {
+      "name": "PHENO",
+      "type": "CHEM_SPEC",
+      "__description": "phenoxy radical",
+      "molecular weight [kg mol-1]": 0.159115
+    },
+    {
+      "name": "HCFC141B",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.116948
+    },
+    {
+      "name": "HCFC142B",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.100494
+    },
+    {
+      "name": "HCFC22",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0864679
+    },
+    {
+      "name": "DMS",
+      "type": "CHEM_SPEC",
+      "__description": "dimethyl sulfide",
+      "molecular weight [kg mol-1]": 0.0621324
+    },
+    {
+      "name": "C2H5OH",
+      "type": "CHEM_SPEC",
+      "__description": "ethanol",
+      "molecular weight [kg mol-1]": 0.0460658
+    },
+    {
+      "name": "HCL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0364601
+    },
+    {
+      "name": "BEPOMUC",
+      "type": "CHEM_SPEC",
+      "__description": "unsaturated dialdehydic epoxide from OH + benzene",
+      "molecular weight [kg mol-1]": 0.126109
+    },
+    {
+      "name": "CHBR3",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.25273
+    },
+    {
+      "name": "H2402",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.259824
+    },
+    {
+      "name": "CO2",
+      "type": "CHEM_SPEC",
+      "__description": "carbon dioxide",
+      "molecular weight [kg mol-1]": 0.0440098
+    },
+    {
+      "name": "BZALD",
+      "type": "CHEM_SPEC",
+      "__description": "benzaldehyde",
+      "molecular weight [kg mol-1]": 0.106121
+    },
+    {
+      "name": "BENZENE",
+      "type": "CHEM_SPEC",
+      "__description": "benzene",
+      "molecular weight [kg mol-1]": 0.0781104
+    },
+    {
+      "name": "C3H7O2",
+      "type": "CHEM_SPEC",
+      "__description": "propylperoxy radical",
+      "molecular weight [kg mol-1]": 0.0750836
+    },
+    {
+      "name": "CH3O2",
+      "type": "CHEM_SPEC",
+      "__description": "methylperoxy radical",
+      "molecular weight [kg mol-1]": 0.047032
+    },
+    {
+      "name": "BCARY",
+      "type": "CHEM_SPEC",
+      "__description": "beta-caryophyllene",
+      "molecular weight [kg mol-1]": 0.204343
+    },
+    {
+      "name": "BIGALD",
+      "type": "CHEM_SPEC",
+      "__description": "lumped aldehyde from terpene ozonolysis",
+      "molecular weight [kg mol-1]": 0.0980982
+    },
+    {
+      "name": "BIGALD2",
+      "type": "CHEM_SPEC",
+      "__description": "4-oxy-2-pentenal, a product of aromatic oxidation",
+      "molecular weight [kg mol-1]": 0.0980982
+    },
+    {
+      "name": "BIGALD3",
+      "type": "CHEM_SPEC",
+      "__description": "2-methyl butenedial, a product of aromatic oxidation",
+      "molecular weight [kg mol-1]": 0.0980982
+    },
+    {
+      "name": "BIGALD4",
+      "type": "CHEM_SPEC",
+      "__description": "2-methyl-4-oxo-2-pentenal, a product of aromatic oxidation",
+      "molecular weight [kg mol-1]": 0.112124
+    },
+    {
+      "name": "BIGALK",
+      "type": "CHEM_SPEC",
+      "__description": "lumped alkanes C>3",
+      "molecular weight [kg mol-1]": 0.0721438
+    },
+    {
+      "name": "H2O2",
+      "type": "CHEM_SPEC",
+      "__description": "hydrogen peroxide",
+      "molecular weight [kg mol-1]": 0.0340136
+    },
+    {
+      "name": "C2H5OOH",
+      "type": "CHEM_SPEC",
+      "__description": "ethyl hydroperoxide",
+      "molecular weight [kg mol-1]": 0.0620652
+    },
+    {
+      "name": "C2H6",
+      "type": "CHEM_SPEC",
+      "__description": "ethane",
+      "molecular weight [kg mol-1]": 0.0300664
+    },
+    {
+      "name": "C3H8",
+      "type": "CHEM_SPEC",
+      "__description": "propane",
+      "molecular weight [kg mol-1]": 0.0440922
+    },
+    {
+      "name": "C3H6",
+      "type": "CHEM_SPEC",
+      "__description": "propene",
+      "molecular weight [kg mol-1]": 0.0420774
+    },
+    {
+      "name": "CH2O",
+      "type": "CHEM_SPEC",
+      "__description": "formaldehyde",
+      "molecular weight [kg mol-1]": 0.0300252
+    },
+    {
+      "name": "CH3CN",
+      "type": "CHEM_SPEC",
+      "__description": "acetonitrile",
+      "molecular weight [kg mol-1]": 0.0410509
+    },
+    {
+      "name": "C2H2",
+      "type": "CHEM_SPEC",
+      "__description": "ethyne",
+      "molecular weight [kg mol-1]": 0.0260368
+    },
+    {
+      "name": "CH3OH",
+      "type": "CHEM_SPEC",
+      "__description": "methanol",
+      "molecular weight [kg mol-1]": 0.03204
+    },
+    {
+      "name": "CH3OOH",
+      "type": "CHEM_SPEC",
+      "__description": "methyl hydroperoxide",
+      "molecular weight [kg mol-1]": 0.0480394
+    },
+    {
+      "name": "CRESOL",
+      "type": "CHEM_SPEC",
+      "__description": "lumped cresols (hydroxymethylbenzenes)",
+      "molecular weight [kg mol-1]": 0.108136
+    },
+    {
+      "name": "ENEO2",
+      "type": "CHEM_SPEC",
+      "__description": "lumped hydroxyperoxy radical from OH + large alkenes",
+      "molecular weight [kg mol-1]": 0.105109
+    },
+    {
+      "name": "MACRO2",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy radical from methacrolein oxidation",
+      "molecular weight [kg mol-1]": 0.119093
+    },
+    {
+      "name": "ISOPAO2",
+      "type": "CHEM_SPEC",
+      "__description": "1,2-isomer of isoprene peroxy radical",
+      "molecular weight [kg mol-1]": 0.11712
+    },
+    {
+      "name": "MALO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.115064
+    },
+    {
+      "name": "ISOPBO2",
+      "type": "CHEM_SPEC",
+      "__description": "1,4-isomer of isoprene peroxy radical",
+      "molecular weight [kg mol-1]": 0.11712
+    },
+    {
+      "name": "MCO3",
+      "type": "CHEM_SPEC",
+      "__description": "peroxy radical from OH abstraction reaction with MACR",
+      "molecular weight [kg mol-1]": 0.101079
+    },
+    {
+      "name": "MDIALO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.117079
+    },
+    {
+      "name": "MEKO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.103094
+    },
+    {
+      "name": "EO2",
+      "type": "CHEM_SPEC",
+      "__description": "hydroxyperoxy radical from OH + ethene chemistry",
+      "molecular weight [kg mol-1]": 0.0770572
+    },
+    {
+      "name": "EO",
+      "type": "CHEM_SPEC",
+      "__description": "hydroxyalkoxy radical from OH + ethene chemistry",
+      "molecular weight [kg mol-1]": 0.0610578
+    },
+    {
+      "name": "GLYOXAL",
+      "type": "CHEM_SPEC",
+      "__description": "glyoxal",
+      "molecular weight [kg mol-1]": 0.0580356,
+      "diffusion coefficient [m2 s-1]": 1e300
+    },
+    {
+      "name": "MPAN",
+      "type": "CHEM_SPEC",
+      "__description": "methacrylol peroxynitrate",
+      "molecular weight [kg mol-1]": 0.147085
+    },
+    {
+      "name": "NC4CH2OH",
+      "type": "CHEM_SPEC",
+      "__description": "nitrooxy-alcohol from NO3+isoprene chemistry",
+      "molecular weight [kg mol-1]": 0.147126,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "ISOPOOH",
+      "type": "CHEM_SPEC",
+      "__description": "unsaturated hydroxyhydroperoxide",
+      "molecular weight [kg mol-1]": 0.118127
+    },
+    {
+      "name": "GLYALD",
+      "type": "CHEM_SPEC",
+      "__description": "glycolaldehyde",
+      "molecular weight [kg mol-1]": 0.0600504
+    },
+    {
+      "name": "HO2",
+      "type": "CHEM_SPEC",
+      "__description": "hydroperoxyl radical",
+      "molecular weight [kg mol-1]": 0.0330062,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "HOCH2OO",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0630314
+    },
+    {
+      "name": "H2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0020148
+    },
+    {
+      "name": "HYDRALD",
+      "type": "CHEM_SPEC",
+      "__description": "lumped unsturated hydroxycarbonyl",
+      "molecular weight [kg mol-1]": 0.100113
+    },
+    {
+      "name": "ISOP",
+      "type": "CHEM_SPEC",
+      "__description": "isoprene",
+      "molecular weight [kg mol-1]": 0.0681142
+    },
+    {
+      "name": "NTERPO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.230232
+    },
+    {
+      "name": "TOLO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.173141
+    },
+    {
+      "name": "TERP2O2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.199219
+    },
+    {
+      "name": "XYLENO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.187166
+    },
+    {
+      "name": "TERPO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.185234
+    },
+    {
+      "name": "XYLOLO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.203166
+    },
+    {
+      "name": "PBZNIT",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.183118
+    },
+    {
+      "name": "XYLENES",
+      "type": "CHEM_SPEC",
+      "__description": "lumped xylenes",
+      "molecular weight [kg mol-1]": 0.106162
+    },
+    {
+      "name": "PO2",
+      "type": "CHEM_SPEC",
+      "__description": "propene peroxy radical",
+      "molecular weight [kg mol-1]": 0.091083
+    },
+    {
+      "name": "TOLUENE",
+      "type": "CHEM_SPEC",
+      "__description": "toluene",
+      "molecular weight [kg mol-1]": 0.0921362
+    },
+    {
+      "name": "XO2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.149119
+    },
+    {
+      "name": "XOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.150126
+    },
+    {
+      "name": "TERPROD2",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.154201
+    },
+    {
+      "name": "MEKOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.104101
+    },
+    {
+      "name": "MACR",
+      "type": "CHEM_SPEC",
+      "__description": "methacrolein",
+      "molecular weight [kg mol-1]": 0.0700878
+    },
+    {
+      "name": "HONITR",
+      "type": "CHEM_SPEC",
+      "__description": "lumped hydroxynitrates from various compounds (formula updated 2017-04-06)",
+      "molecular weight [kg mol-1]": 0.1331,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "ISOPNITA",
+      "type": "CHEM_SPEC",
+      "__description": "1,2-hydroxynitrate from OH+isoprene chemistry",
+      "molecular weight [kg mol-1]": 0.147126,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "ISOPNOOH",
+      "type": "CHEM_SPEC",
+      "__description": "nitroxy-hydroperoxide from NO3+isoprene chemistry",
+      "molecular weight [kg mol-1]": 0.163125
+    },
+    {
+      "name": "IEPOX",
+      "type": "CHEM_SPEC",
+      "__description": "isoprene epoxide",
+      "molecular weight [kg mol-1]": 0.118127
+    },
+    {
+      "name": "ONITR",
+      "type": "CHEM_SPEC",
+      "__description": "lumped hydroxynitrates (formula updated 2017-04-06)",
+      "molecular weight [kg mol-1]": 0.147126,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "H2SO4",
+      "type": "CHEM_SPEC",
+      "__description": "sulfuric acid",
+      "molecular weight [kg mol-1]": 0.0980784
+    },
+    {
+      "name": "N2O",
+      "type": "CHEM_SPEC",
+      "__description": "nitrous oxide",
+      "molecular weight [kg mol-1]": 0.0440129
+    },
+    {
+      "name": "NO3",
+      "type": "CHEM_SPEC",
+      "__description": "nitrate radical",
+      "molecular weight [kg mol-1]": 0.0620049,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "OH",
+      "type": "CHEM_SPEC",
+      "__description": "hydroxyl radical",
+      "molecular weight [kg mol-1]": 0.0170068
+    },
+    {
+      "name": "PHENOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.176122
+    },
+    {
+      "name": "PHENOL",
+      "type": "CHEM_SPEC",
+      "__description": "phenol, product of benzene chemistry",
+      "molecular weight [kg mol-1]": 0.0941098
+    },
+    {
+      "name": "XYLOL",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.122161
+    },
+    {
+      "name": "ROOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0900756
+    },
+    {
+      "name": "O3",
+      "type": "CHEM_SPEC",
+      "__description": "ozone",
+      "molecular weight [kg mol-1]": 0.0479982
+    },
+    {
+      "name": "TERPOOH",
+      "type": "CHEM_SPEC",
+      "__description": "Hydroxy hydroperoxide from terpene 0 double bonds",
+      "molecular weight [kg mol-1]": 0.186241
+    },
+    {
+      "name": "TOLOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.174148
+    },
+    {
+      "name": "XYLENOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.188174
+    },
+    {
+      "name": "XYLOLOOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.204173
+    },
+    {
+      "name": "CO",
+      "type": "CHEM_SPEC",
+      "__description": "carbon monoxide",
+      "molecular weight [kg mol-1]": 0.0280104
+    },
+    {
+      "name": "CH3COOH",
+      "type": "CHEM_SPEC",
+      "__description": "acetic acid",
+      "molecular weight [kg mol-1]": 0.0600504
+    },
+    {
+      "name": "CH3CHO",
+      "type": "CHEM_SPEC",
+      "__description": "acetaldehyde",
+      "molecular weight [kg mol-1]": 0.044051
+    },
+    {
+      "name": "BIGALD1",
+      "type": "CHEM_SPEC",
+      "__description": "butenedial, a product of aromatic oxidation",
+      "molecular weight [kg mol-1]": 0.0840724
+    },
+    {
+      "name": "ALKOOH",
+      "type": "CHEM_SPEC",
+      "__description": "lumped alkane peroxide",
+      "molecular weight [kg mol-1]": 0.104143
+    },
+    {
+      "name": "DICARBO2",
+      "type": "CHEM_SPEC",
+      "__description": "acylperoxy radical formed from aromatic oxidation, via unsaturated dicarbonyl chemistry",
+      "molecular weight [kg mol-1]": 0.12909
+    },
+    {
+      "name": "BENZOOH",
+      "type": "CHEM_SPEC",
+      "__description": "bicyclic hydroperoxide from OH + benzene",
+      "molecular weight [kg mol-1]": 0.160122
+    },
+    {
+      "name": "ALKO2",
+      "type": "CHEM_SPEC",
+      "__description": "lumped alkane peroxy radical from BIGALK",
+      "molecular weight [kg mol-1]": 0.103135
+    },
+    {
+      "name": "HO2NO2",
+      "type": "CHEM_SPEC",
+      "__description": "pernitric acid",
+      "molecular weight [kg mol-1]": 0.0790117
+    },
+    {
+      "name": "C3H7OOH",
+      "type": "CHEM_SPEC",
+      "__description": "propyl hydrogen peroxide",
+      "molecular weight [kg mol-1]": 0.076091
+    },
+    {
+      "name": "NH3",
+      "type": "CHEM_SPEC",
+      "__description": "ammonia",
+      "molecular weight [kg mol-1]": 0.017031
+    },
+    {
+      "name": "TERP2OOH",
+      "type": "CHEM_SPEC",
+      "__description": "2nd generation terpene hydroperoxide",
+      "molecular weight [kg mol-1]": 0.200226
+    },
+    {
+      "name": "POOH",
+      "type": "CHEM_SPEC",
+      "__description": "",
+      "molecular weight [kg mol-1]": 0.0920904
+    },
+    {
+      "name": "NOA",
+      "type": "CHEM_SPEC",
+      "__description": "nitrooxyacetone, largely from NO3+propene chemistry",
+      "molecular weight [kg mol-1]": 0.119074
+    },
+    {
+      "name": "NC4CHO",
+      "type": "CHEM_SPEC",
+      "__description": "nitrooxy-aldehyde from NO3+isoprene chemistry",
+      "molecular weight [kg mol-1]": 0.145111,
+      "diffusion coefficient [m2 s-1]": 1000.0
+    },
+    {
+      "name": "TEPOMUC",
+      "type": "CHEM_SPEC",
+      "__description": "toluene, xylenes product",
+      "molecular weight [kg mol-1]": 0.140134
+    },
+    {
+      "name": "NH4",
+      "type": "CHEM_SPEC",
+      "__description": "Ammonium",
+      "molecular weight [kg mol-1]": 0
+    },
+    {
+      "name": "M",
+      "type": "CHEM_SPEC",
+      "tracer type": "THIRD_BODY"
+    }
+
+  ]
+}

--- a/src/acom_music_box/examples/configs/ts1/my_config.json
+++ b/src/acom_music_box/examples/configs/ts1/my_config.json
@@ -1,0 +1,584 @@
+{
+  "box model options": {
+    "grid": "box",
+    "chemistry time step [sec]": 60.0,
+    "output time step [sec]": 600.0,
+    "simulation length [hour]": 1.0
+  },
+  "chemical species": {
+    "TEPOMUC": {
+      "initial value [mol m-3]": 2.21e-10
+    },
+    "NC4CHO": {
+      "initial value [mol m-3]": 3.67e-11
+    },
+    "NOA": {
+      "initial value [mol m-3]": 5.46e-09
+    },
+    "POOH": {
+      "initial value [mol m-3]": 9.24e-10
+    },
+    "TERP2OOH": {
+      "initial value [mol m-3]": 5.96e-10
+    },
+    "NH3": {
+      "initial value [mol m-3]": 7.59e-08
+    },
+    "C3H7OOH": {
+      "initial value [mol m-3]": 7.87e-11
+    },
+    "HO2NO2": {
+      "initial value [mol m-3]": 7.99e-10
+    },
+    "ALKO2": {
+      "initial value [mol m-3]": 1.39e-11
+    },
+    "BENZOOH": {
+      "initial value [mol m-3]": 5.78e-12
+    },
+    "DICARBO2": {
+      "initial value [mol m-3]": 1.55e-13
+    },
+    "ALKOOH": {
+      "initial value [mol m-3]": 3.79e-10
+    },
+    "BIGALD1": {
+      "initial value [mol m-3]": 6.47e-11
+    },
+    "CH3CHO": {
+      "initial value [mol m-3]": 2.51e-08
+    },
+    "CH3COOH": {
+      "initial value [mol m-3]": 8.2e-09
+    },
+    "CO": {
+      "initial value [mol m-3]": 3.25e-06
+    },
+    "XYLOLOOH": {
+      "initial value [mol m-3]": 1.31e-11
+    },
+    "XYLENOOH": {
+      "initial value [mol m-3]": 1.5e-10
+    },
+    "TOLOOH": {
+      "initial value [mol m-3]": 9.69e-11
+    },
+    "TERPOOH": {
+      "initial value [mol m-3]": 2.46e-10
+    },
+    "O3": {
+      "initial value [mol m-3]": 2.49e-06
+    },
+    "ROOH": {
+      "initial value [mol m-3]": 4.4e-10
+    },
+    "XYLOL": {
+      "initial value [mol m-3]": 9.92e-11
+    },
+    "PHENOL": {
+      "initial value [mol m-3]": 9.49e-11
+    },
+    "PHENOOH": {
+      "initial value [mol m-3]": 9.15e-12
+    },
+    "OH": {
+      "initial value [mol m-3]": 2.52e-11
+    },
+    "NO3": {
+      "initial value [mol m-3]": 9.32e-12
+    },
+    "N2O": {
+      "initial value [mol m-3]": 1.27e-05
+    },
+    "H2SO4": {
+      "initial value [mol m-3]": 2.27e-11
+    },
+    "ONITR": {
+      "initial value [mol m-3]": 2.67e-09
+    },
+    "IEPOX": {
+      "initial value [mol m-3]": 5.84e-09
+    },
+    "ISOPNOOH": {
+      "initial value [mol m-3]": 9.16e-11
+    },
+    "ISOPNITA": {
+      "initial value [mol m-3]": 1.62e-09
+    },
+    "HONITR": {
+      "initial value [mol m-3]": 6.79e-09
+    },
+    "MACR": {
+      "initial value [mol m-3]": 1.06e-08
+    },
+    "MEKOOH": {
+      "initial value [mol m-3]": 6.15e-11
+    },
+    "TERPROD2": {
+      "initial value [mol m-3]": 3.81e-09
+    },
+    "XOOH": {
+      "initial value [mol m-3]": 7.93e-09
+    },
+    "XO2": {
+      "initial value [mol m-3]": 1.12e-10
+    },
+    "TOLUENE": {
+      "initial value [mol m-3]": 4.88e-09
+    },
+    "PO2": {
+      "initial value [mol m-3]": 1.46e-11
+    },
+    "XYLENES": {
+      "initial value [mol m-3]": 2.82e-09
+    },
+    "PBZNIT": {
+      "initial value [mol m-3]": 1.78e-10
+    },
+    "XYLOLO2": {
+      "initial value [mol m-3]": 4.62e-13
+    },
+    "TERPO2": {
+      "initial value [mol m-3]": 1.29e-11
+    },
+    "XYLENO2": {
+      "initial value [mol m-3]": 4.98e-12
+    },
+    "TERP2O2": {
+      "initial value [mol m-3]": 2.15e-11
+    },
+    "TOLO2": {
+      "initial value [mol m-3]": 3.23e-12
+    },
+    "NTERPO2": {
+      "initial value [mol m-3]": 9.18e-13
+    },
+    "ISOP": {
+      "initial value [mol m-3]": 1.23e-08
+    },
+    "HYDRALD": {
+      "initial value [mol m-3]": 1.49e-08
+    },
+    "H2": {
+      "initial value [mol m-3]": 1.93e-05
+    },
+    "HOCH2OO": {
+      "initial value [mol m-3]": 1.07e-13
+    },
+    "HO2": {
+      "initial value [mol m-3]": 1.69e-09
+    },
+    "GLYALD": {
+      "initial value [mol m-3]": 4.58e-08
+    },
+    "ISOPOOH": {
+      "initial value [mol m-3]": 4.68e-09
+    },
+    "NC4CH2OH": {
+      "initial value [mol m-3]": 7.3e-13
+    },
+    "MPAN": {
+      "initial value [mol m-3]": 3.11e-09
+    },
+    "GLYOXAL": {
+      "initial value [mol m-3]": 1.25e-08
+    },
+    "EO": {
+      "initial value [mol m-3]": 9.93e-18
+    },
+    "EO2": {
+      "initial value [mol m-3]": 4.04e-11
+    },
+    "MEKO2": {
+      "initial value [mol m-3]": 2.81e-12
+    },
+    "MDIALO2": {
+      "initial value [mol m-3]": 1.61e-13
+    },
+    "MCO3": {
+      "initial value [mol m-3]": 9.23e-12
+    },
+    "ISOPBO2": {
+      "initial value [mol m-3]": 9.08e-11
+    },
+    "MALO2": {
+      "initial value [mol m-3]": 1.07e-13
+    },
+    "ISOPAO2": {
+      "initial value [mol m-3]": 1.39e-10
+    },
+    "MACRO2": {
+      "initial value [mol m-3]": 1.09e-10
+    },
+    "ENEO2": {
+      "initial value [mol m-3]": 7.98e-12
+    },
+    "CRESOL": {
+      "initial value [mol m-3]": 1.06e-10
+    },
+    "CH3OOH": {
+      "initial value [mol m-3]": 1.69e-08
+    },
+    "CH3OH": {
+      "initial value [mol m-3]": 2.74e-07
+    },
+    "C2H2": {
+      "initial value [mol m-3]": 2.13e-08
+    },
+    "CH3CN": {
+      "initial value [mol m-3]": 4.66e-09
+    },
+    "CH2O": {
+      "initial value [mol m-3]": 2.44e-07
+    },
+    "C3H6": {
+      "initial value [mol m-3]": 2.42e-09
+    },
+    "C3H8": {
+      "initial value [mol m-3]": 9.7e-09
+    },
+    "C2H6": {
+      "initial value [mol m-3]": 2.93e-08
+    },
+    "C2H5OOH": {
+      "initial value [mol m-3]": 7.99e-11
+    },
+    "H2O2": {
+      "initial value [mol m-3]": 7.36e-08
+    },
+    "BIGALK": {
+      "initial value [mol m-3]": 1.9e-08
+    },
+    "BIGALD4": {
+      "initial value [mol m-3]": 7.34e-10
+    },
+    "BIGALD3": {
+      "initial value [mol m-3]": 6.83e-11
+    },
+    "BIGALD2": {
+      "initial value [mol m-3]": 6.58e-11
+    },
+    "BIGALD": {
+      "initial value [mol m-3]": 1.33e-11
+    },
+    "BCARY": {
+      "initial value [mol m-3]": 5.04e-12
+    },
+    "CH3O2": {
+      "initial value [mol m-3]": 3.34e-10
+    },
+    "C3H7O2": {
+      "initial value [mol m-3]": 2.31e-12
+    },
+    "BENZENE": {
+      "initial value [mol m-3]": 2.67e-09
+    },
+    "BZALD": {
+      "initial value [mol m-3]": 4.7e-10
+    },
+    "CO2": {
+      "initial value [mol m-3]": 0.0156
+    },
+    "H2402": {
+      "initial value [mol m-3]": 1.52e-11
+    },
+    "CHBR3": {
+      "initial value [mol m-3]": 3.87e-11
+    },
+    "BEPOMUC": {
+      "initial value [mol m-3]": 5.4e-12
+    },
+    "HCL": {
+      "initial value [mol m-3]": 8.17e-10
+    },
+    "C2H5OH": {
+      "initial value [mol m-3]": 2.75e-08
+    },
+    "DMS": {
+      "initial value [mol m-3]": 1.74e-10
+    },
+    "HCFC22": {
+      "initial value [mol m-3]": 9.07e-09
+    },
+    "HCFC142B": {
+      "initial value [mol m-3]": 8.24e-10
+    },
+    "HCFC141B": {
+      "initial value [mol m-3]": 9.29e-10
+    },
+    "PHENO": {
+      "initial value [mol m-3]": 1e-12
+    },
+    "O1D": {
+      "initial value [mol m-3]": 1.53e-19
+    },
+    "OCLO": {
+      "initial value [mol m-3]": 7.68e-19
+    },
+    "O": {
+      "initial value [mol m-3]": 2.85e-14
+    },
+    "CH3COCH3": {
+      "initial value [mol m-3]": 7.37e-08
+    },
+    "CH3COCHO": {
+      "initial value [mol m-3]": 1.95e-08
+    },
+    "C2H5O2": {
+      "initial value [mol m-3]": 1.55e-12
+    },
+    "C2H4": {
+      "initial value [mol m-3]": 2.51e-08
+    },
+    "BIGENE": {
+      "initial value [mol m-3]": 6.59e-10
+    },
+    "HOCL": {
+      "initial value [mol m-3]": 2.11e-12
+    },
+    "HOBR": {
+      "initial value [mol m-3]": 1.65e-12
+    },
+    "HBR": {
+      "initial value [mol m-3]": 4.48e-11
+    },
+    "HCOOH": {
+      "initial value [mol m-3]": 8.79e-09
+    },
+    "CLONO2": {
+      "initial value [mol m-3]": 4.09e-11
+    },
+    "CLO": {
+      "initial value [mol m-3]": 8.06e-14
+    },
+    "CL2O2": {
+      "initial value [mol m-3]": 1.8899999999999997e-23
+    },
+    "CL2": {
+      "initial value [mol m-3]": 1.01e-16
+    },
+    "CL": {
+      "initial value [mol m-3]": 1.07e-15
+    },
+    "BRONO2": {
+      "initial value [mol m-3]": 1.22e-11
+    },
+    "BRO": {
+      "initial value [mol m-3]": 1.95e-13
+    },
+    "BRCL": {
+      "initial value [mol m-3]": 9.18e-19
+    },
+    "BR": {
+      "initial value [mol m-3]": 3.67e-14
+    },
+    "NO": {
+      "initial value [mol m-3]": 1.47e-08
+    },
+    "CH3CCL3": {
+      "initial value [mol m-3]": 5.55e-11
+    },
+    "CH3BR": {
+      "initial value [mol m-3]": 2.37e-10
+    },
+    "CH2BR2": {
+      "initial value [mol m-3]": 4.32e-11
+    },
+    "CFC12": {
+      "initial value [mol m-3]": 1.92e-08
+    },
+    "CFC115": {
+      "initial value [mol m-3]": 3.29e-10
+    },
+    "CFC114": {
+      "initial value [mol m-3]": 6.19e-10
+    },
+    "CFC113": {
+      "initial value [mol m-3]": 2.66e-09
+    },
+    "CFC11": {
+      "initial value [mol m-3]": 8.5e-09
+    },
+    "CF3BR": {
+      "initial value [mol m-3]": 1.26e-10
+    },
+    "CF2CLBR": {
+      "initial value [mol m-3]": 1.24e-10
+    },
+    "CCL4": {
+      "initial value [mol m-3]": 2.96e-09
+    },
+    "NTERPOOH": {
+      "initial value [mol m-3]": 9.37e-11
+    },
+    "EOOH": {
+      "initial value [mol m-3]": 3.56e-09
+    },
+    "NO2": {
+      "initial value [mol m-3]": 6.37e-08
+    },
+    "HPALD": {
+      "initial value [mol m-3]": 3.56e-10
+    },
+    "HYAC": {
+      "initial value [mol m-3]": 4.88e-08
+    },
+    "TERPROD1": {
+      "initial value [mol m-3]": 1.68e-09
+    },
+    "C6H5O2": {
+      "initial value [mol m-3]": 6.23e-12
+    },
+    "CH3CO3": {
+      "initial value [mol m-3]": 8.32e-11
+    },
+    "CH3CL": {
+      "initial value [mol m-3]": 2.07e-08
+    },
+    "CH4": {
+      "initial value [mol m-3]": 7.03e-05
+    },
+    "SO2": {
+      "initial value [mol m-3]": 6.15e-08
+    },
+    "CH3COOOH": {
+      "initial value [mol m-3]": 7.19e-09
+    },
+    "ACBZO2": {
+      "initial value [mol m-3]": 3.54e-13
+    },
+    "HNO3": {
+      "initial value [mol m-3]": 1.04e-07
+    },
+    "TERPNIT": {
+      "initial value [mol m-3]": 8.28e-10
+    },
+    "IVOC": {
+      "initial value [mol m-3]": 2.06e-09
+    },
+    "PHENO2": {
+      "initial value [mol m-3]": 2.54e-13
+    },
+    "RO2": {
+      "initial value [mol m-3]": 7.13e-12
+    },
+    "ISOPNO3": {
+      "initial value [mol m-3]": 5.35e-13
+    },
+    "SVOC": {
+      "initial value [mol m-3]": 1.98e-10
+    },
+    "HCN": {
+      "initial value [mol m-3]": 1.9e-08
+    },
+    "N2O5": {
+      "initial value [mol m-3]": 1e-11
+    },
+    "MTERP": {
+      "initial value [mol m-3]": 1.09e-09
+    },
+    "MEK": {
+      "initial value [mol m-3]": 1.04e-08
+    },
+    "H": {
+      "initial value [mol m-3]": 9.67e-18
+    },
+    "S": {
+      "initial value [mol m-3]": 1.1e-26
+    },
+    "SO": {
+      "initial value [mol m-3]": 1.22e-20
+    },
+    "OCS": {
+      "initial value [mol m-3]": 1.96e-08
+    },
+    "SO3": {
+      "initial value [mol m-3]": 1.75e-17
+    },
+    "ISOPNITB": {
+      "initial value [mol m-3]": 1.05e-09
+    },
+    "SOAG4": {
+      "initial value [mol m-3]": 2.25e-08
+    },
+    "SOAG3": {
+      "initial value [mol m-3]": 4.27e-09
+    },
+    "SOAG2": {
+      "initial value [mol m-3]": 1.4e-09
+    },
+    "SOAG1": {
+      "initial value [mol m-3]": 2.14e-10
+    },
+    "SOAG0": {
+      "initial value [mol m-3]": 3.33e-11
+    },
+    "MACROOH": {
+      "initial value [mol m-3]": 1.21e-09
+    },
+    "MVK": {
+      "initial value [mol m-3]": 2.61e-08
+    },
+    "PAN": {
+      "initial value [mol m-3]": 4.25e-08
+    },
+    "BZOO": {
+      "initial value [mol m-3]": 8.81e-13
+    },
+    "BENZO2": {
+      "initial value [mol m-3]": 2.09e-13
+    },
+    "F": {
+      "initial value [mol m-3]": 3.89e-28
+    },
+    "HF": {
+      "initial value [mol m-3]": 1.81e-11
+    },
+    "COFCL": {
+      "initial value [mol m-3]": 7.92e-12
+    },
+    "COF2": {
+      "initial value [mol m-3]": 5.24e-11
+    },
+    "C6H5OOH": {
+      "initial value [mol m-3]": 4.2e-10
+    },
+    "BZOOH": {
+      "initial value [mol m-3]": 2.68e-11
+    },
+    "ALKNIT": {
+      "initial value [mol m-3]": 8.72e-10
+    },
+    "N2": {
+      "initial value [mol m-3]": 33.1007671
+    },
+    "O2": {
+      "initial value [mol m-3]": 8.90261411
+    }
+  },
+  "environmental conditions": {
+    "temperature": {
+      "initial value [K]": 287.45
+    },
+    "pressure": {
+      "initial value [Pa]": 1013.199
+    }
+  },
+  "evolving conditions": {},
+  "initial conditions": {
+  },
+  "model components": [
+    {
+      "type": "CAMP",
+      "configuration file": "camp_data/config.json",
+      "override species": {
+        "M": {
+          "mixing ratio mol mol-1": 1.0
+        }
+      },
+      "suppress output": {
+        "M": {}
+      }
+    }
+  ]
+}

--- a/src/acom_music_box/examples/examples.py
+++ b/src/acom_music_box/examples/examples.py
@@ -41,10 +41,15 @@ class _Examples:
         short_name='Analytical',
         folder_name='analytical',
         description='An example of an analytical solution to a simple chemical system')
+    TS1 = Example.from_config(
+        display_name='Tropical Stratosphere 1',
+        short_name='TS1',
+        folder_name='ts1',
+        description='Many species involved in tropospheric-stratospheric chemistry')
 
     @classmethod
     def get_all(cls):
-        return [cls.CarbonBond5, cls.Chapman, cls.FlowTube, cls.Analytical]
+        return [cls.CarbonBond5, cls.Chapman, cls.FlowTube, cls.Analytical, cls.TS1]
 
     def __iter__(self):
         return iter(self.get_all())


### PR DESCRIPTION
Adds TS1 as an example

```
:: music_box -h                            
usage: music_box [-h] [-c CONFIG] [-e {CB5,Chapman,FlowTube,Analytical,TS1}] [-o OUTPUT] [-v] [--version] [--color-output] [--plot PLOT]

MusicBox simulation runner.

options:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        Path to the configuration file. If --example is provided, this argument is ignored.
  -e {CB5,Chapman,FlowTube,Analytical,TS1}, --example {CB5,Chapman,FlowTube,Analytical,TS1}
                        Name of the example to use. Overrides --config.
                        Available examples:
                        CB5: Carbon bond 5
                        Chapman: The Chapman cycle with conditions over Boulder, Colorado
                        FlowTube: A fictitious flow tube experiment
                        Analytical: An example of an analytical solution to a simple chemical system
                        TS1: Many species involved in tropospheric-stratospheric chemistry
  -o OUTPUT, --output OUTPUT
                        Path to save the output file, including the file name. If not provided, result will be printed to the console.
  -v, --verbose         Increase logging verbosity. Use -v for info, -vv for debug.
  --version             show program's version number and exit
  --color-output        Enable color output for logs.
  --plot PLOT           Plot a comma-separated list of species if gnuplot is available (e.g., CONC.A,CONC.B).
```

Can be run with 
```
music_box -e TS1
```