### PR TITLE
Create species map from the chemical species common to both WACCM and MUSICA species.json TS1

### DIFF
--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -73,18 +73,28 @@ def safeFloat(numString):
 
 # Build and return dictionary of WACCM variable names
 # and their MusicBox equivalents.
-def getMusicaDictionary():
-    varMap = {
-        "T": "temperature",
-        "PS": "pressure",
-        "N2O": "N2O",
-        "H2O2": "H2O2",
-        "O3": "O3",
-        "NH3": "NH3",
-        "CH4": "CH4"
-    }
+# waccmSpecies = list of variable names in the WACCM model output
+# musicaSpecies = list of variable names in species.json
+# return ordered dictionary
+def getMusicaDictionary(waccmSpecies=None, musicaSpecies=None):
+    if ((waccmSpecies is None) or (musicaSpecies is None)):
+        logger.warning("No species map found for WACCM or MUSICA.")
 
-    return (dict(sorted(varMap.items())))
+        # build a simple spiecies map
+        varMap = {
+            "T": "temperature",
+            "PS": "pressure",
+            "N2O": "N2O",
+            "H2O2": "H2O2",
+            "O3": "O3",
+            "NH3": "NH3",
+            "CH4": "CH4"
+        }
+
+        return (dict(sorted(varMap.items())))
+
+    # create new list of species common to both lists
+    return(None)
 
 
 # Read array values at a single lat-lon-time point.

--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -101,8 +101,22 @@ def getWaccmSpecies(when, modelDir):
 # corresponding to the same chemical species in WACCM.
 # templateDir = directory containing configuration files and camp_data
 # return list of variable names
-def getMusicaSpecies(tempateDir):
+def getMusicaSpecies(templateDir):
+    # find the standard configuration file and parse it
+    myConfigFile = os.path.join(templateDir, "camp_data", "species.json")
+    with open(myConfigFile) as jsonFile:
+        myConfig = json.load(jsonFile)
+
+    # locate the section for chemical species
+    chemSpeciesTag = "camp-data"
+    chemSpecies = myConfig[chemSpeciesTag]
+
+    # retrieve just the names
     musicaNames = []
+    for spec in chemSpecies:
+        specName = spec.get("name")
+        if (specName):
+            musicaNames.append(spec.get("name"))
 
     return(musicaNames)
 
@@ -116,7 +130,7 @@ def getMusicaDictionary(waccmSpecies=None, musicaSpecies=None):
     if ((waccmSpecies is None) or (musicaSpecies is None)):
         logger.warning("No species map found for WACCM or MUSICA.")
 
-        # build a simple spiecies map
+        # build a simple species map
         varMap = {
             "T": "temperature",
             "PS": "pressure",

--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -71,6 +71,42 @@ def safeFloat(numString):
     return result
 
 
+# Create and return list of WACCM chemical species
+# that will be mapped to MUSICA.
+# when = date and time to extract
+# modelDir = directory containing model output
+# return list of variable names
+def getWaccmSpecies(when, modelDir):
+    # create the filename
+    waccmFilename = ("f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{:4d}-{:02d}-{:02}-00000.nc"
+                     .format(when.year, when.month, when.day))
+    logger.info("WACCM species file = {}".format(waccmFilename))
+
+    # open dataset for reading
+    waccmDataSet = xarray.open_dataset("{}/{}".format(modelDir, waccmFilename))
+
+    # collect the data variables
+    waccmNames = [varName for varName in waccmDataSet.data_vars]
+
+    # To do: remove extraneous non-chemical vars like date and time
+    # Idea: use the dimensions to filter out non-chemicals
+
+    # close the NetCDF file
+    waccmDataSet.close()
+
+    return(waccmNames)
+
+
+# Create list of chemical species in MUSICA,
+# corresponding to the same chemical species in WACCM.
+# templateDir = directory containing configuration files and camp_data
+# return list of variable names
+def getMusicaSpecies(tempateDir):
+    musicaNames = []
+
+    return(musicaNames)
+
+
 # Build and return dictionary of WACCM variable names
 # and their MusicBox equivalents.
 # waccmSpecies = list of variable names in the WACCM model output
@@ -352,11 +388,17 @@ def main():
     if ("template" in myArgs):
         template = myArgs.get("template")
 
-    logger.info("Retrieve WACCM conditions at ({} North, {} East)   when {}."
-                .format(lat, lon, retrieveWhen))
+    # read and glean chemical species from WACCM and MUSICA
+    waccmChems = getWaccmSpecies(retrieveWhen, waccmDir)
+    logger.info("waccmChems are {}".format(waccmChems))
+    musicaChems = getMusicaSpecies(template)
+    logger.info("musicaChems are {}".format(musicaChems))
 
     # Read named variables from WACCM model output.
-    varValues = readWACCM(getMusicaDictionary(),
+    logger.info("Retrieve WACCM conditions at ({} North, {} East)   when {}."
+                .format(lat, lon, retrieveWhen))
+    commonDict = getMusicaDictionary()
+    varValues = readWACCM(commonDict,
                           lat, lon, retrieveWhen, waccmDir)
     logger.info("Original WACCM varValues = {}".format(varValues))
 


### PR DESCRIPTION
There are **75** chemical species currently mapped.
The python code has more diagnistics than we need for production, but in these early stages I find the extra info useful.
Logger gives warnings and the list of species not mapped, because chemical is present in only one list.