### PR TITLE
Output musicbox interactive compatible zip

### DIFF
--- a/sample_waccm_data/README.md
+++ b/sample_waccm_data/README.md
@@ -25,5 +25,5 @@ for root, _, files in os.walk('data'):
 You can extract a coniguraiton file with 
 
 ```
-waccmToMusicBox waccmDir="./sample_waccm_data" musicaDir="src/acom_music_box/examples/configs/ts1" date="20240904" time="07:00" latitude=3.1 longitude=101.7 template=src/acom_music_box/examples/configs/ts1/
+waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7
 ```

--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -14,6 +14,9 @@ import json
 import sys
 import os
 import shutil
+import tempfile
+import zipfile
+from acom_music_box import Examples
 
 import logging
 logger = logging.getLogger(__name__)
@@ -73,17 +76,15 @@ def safeFloat(numString):
 
 # Create and return list of WACCM chemical species
 # that will be mapped to MUSICA.
-# when = date and time to extract
 # modelDir = directory containing model output
+# waccmFilename = name of WACCM model output file
 # return list of variable names
-def getWaccmSpecies(when, modelDir):
+def getWaccmSpecies(modelDir, waccmFilename):
     # create the filename
-    waccmFilename = ("f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{:4d}-{:02d}-{:02}-00000.nc"
-                     .format(when.year, when.month, when.day))
-    logger.info("WACCM species file = {}".format(waccmFilename))
+    logger.info(f"WACCM species file = {waccmFilename}")
 
     # open dataset for reading
-    waccmDataSet = xarray.open_dataset("{}/{}".format(modelDir, waccmFilename))
+    waccmDataSet = xarray.open_dataset(os.path.join(modelDir, waccmFilename))
 
     # collect the data variables
     waccmNames = [varName for varName in waccmDataSet.data_vars]
@@ -150,9 +151,9 @@ def getMusicaDictionary(waccmSpecies=None, musicaSpecies=None):
     waccmOnly = [species for species in waccmSpecies if species not in musicaSpecies]
     musicaOnly = [species for species in musicaSpecies if species not in waccmSpecies]
     if (len(waccmOnly) > 0):
-        logger.warning("The following chemical species are only in WACCM: {}".format(waccmOnly))
+        logger.warning(f"The following chemical species are only in WACCM: {waccmOnly}")
     if (len(musicaOnly) > 0):
-        logger.warning("The following chemical species are only in MUSICA: {}".format(musicaOnly))
+        logger.warning(f"The following chemical species are only in MUSICA: {musicaOnly}")
 
     # build the dictionary
     # To do: As of September 4, 2024 this is not much of a map,
@@ -164,7 +165,7 @@ def getMusicaDictionary(waccmSpecies=None, musicaSpecies=None):
         "PS": "pressure"
     }
 
-    logger.info("inCommon = {}".format(inCommon))
+    logger.info(f"inCommon = {inCommon}")
     for varName in inCommon:
         varMap[varName] = varName
 
@@ -178,45 +179,37 @@ def getMusicaDictionary(waccmSpecies=None, musicaSpecies=None):
 # modelDir = directory containing model output
 # return dictionary of MUSICA variable names, values, and units
 def readWACCM(waccmMusicaDict, latitude, longitude,
-              when, modelDir):
+              when, modelDir, waccmFilename):
 
-    # create the filename
-    waccmFilename = ("f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{:4d}-{:02d}-{:02}-00000.nc"
-                     .format(when.year, when.month, when.day))
-    logger.info("WACCM file = {}".format(waccmFilename))
+    logger.info(f"WACCM file = {waccmFilename}")
 
     # open dataset for reading
-    waccmDataSet = xarray.open_dataset("{}/{}".format(modelDir, waccmFilename))
+    waccmDataSet = xarray.open_dataset(os.path.join(modelDir, waccmFilename))
     if (False):
         # diagnostic to look at dataset structure
-        logger.info("WACCM dataset = {}".format(waccmDataSet))
+        logger.info(f"WACCM dataset = {waccmDataSet}")
 
     # retrieve all vars at a single point
     whenStr = when.strftime("%Y-%m-%d %H:%M:%S")
-    logger.info("whenStr = {}".format(whenStr))
+    logger.info(f"whenStr = {whenStr}")
     singlePoint = waccmDataSet.sel(lon=longitude, lat=latitude, lev=1000.0,
                                    time=whenStr, method="nearest")
     if (False):
         # diagnostic to look at single point structure
-        logger.info("WACCM singlePoint = {}".format(singlePoint))
+        logger.info(f"WACCM singlePoint = {singlePoint}")
 
     # loop through vars and build another dictionary
     musicaDict = {}
     for waccmKey, musicaName in waccmMusicaDict.items():
         if waccmKey not in singlePoint:
-            logger.warning("Requested variable {} not found in WACCM model output."
-                           .format(waccmKey))
+            logger.warning(f"Requested variable {waccmKey} not found in WACCM model output.")
             musicaTuple = (waccmKey, None, None)
             musicaDict[musicaName] = musicaTuple
             continue
 
         chemSinglePoint = singlePoint[waccmKey]
         if (True):
-            logger.info(
-                "WACCM chemical {} = value {} {}".format(
-                    waccmKey,
-                    chemSinglePoint.values,
-                    chemSinglePoint.units))
+            logger.info(f"WACCM chemical {waccmKey} = value {chemSinglePoint.values} {chemSinglePoint.units}")
         musicaTuple = (waccmKey, float(chemSinglePoint.values.mean()), chemSinglePoint.units)   # from 0-dim array
         musicaDict[musicaName] = musicaTuple
 
@@ -254,9 +247,9 @@ def convertWaccm(varDict):
     # retrieve temperature and pressure from WACCM
     temperature = varDict["temperature"][valueIndex]
     pressure = varDict["pressure"][valueIndex]
-    logger.info("temperature = {} K   pressure = {} Pa".format(temperature, pressure))
+    logger.info(f"temperature = {temperature} K   pressure = {pressure} Pa")
     air_density = calcAirDensity(temperature, pressure)
-    logger.info("air density = {} mol m-3".format(air_density))
+    logger.info(f"air density = {air_density} mol m-3")
 
     for key, vTuple in varDict.items():
         # convert moles / mole to moles / cubic meter
@@ -291,7 +284,7 @@ def writeInitCSV(initValues, filename):
         else:
             fp.write(",")
 
-        fp.write("{}".format(value[valueIndex]))
+        fp.write(f"{value[valueIndex]}")
     fp.write("\n")
 
     fp.close()
@@ -307,8 +300,7 @@ def writeInitJSON(initValues, filename):
     initConfig = {dictName: {}}
 
     for key, value in initValues.items():
-        initConfig[dictName][key] = {
-            "initial value [{}]".format(value[unitIndex]): value[valueIndex]}
+        initConfig[dictName][key] = {f"initial value [{value[unitIndex]}]": value[valueIndex]}
 
     # write JSON content to the file
     fpJson = open(filename, "w")
@@ -320,90 +312,84 @@ def writeInitJSON(initValues, filename):
     return
 
 
-# Reproduce the MusicBox configuration with new initial values.
+# Reproduce the MusicBox configuration with new initial values and write to config.zip in the current directory
 # initValues = dictionary of Musica varnames and (WACCM name, value, units)
 # templateDir = directory containing configuration files and camp_data
-# destDir = the template will be created in this directory
-def insertIntoTemplate(initValues, templateDir, destDir):
+def insertIntoTemplate(initValues, templateDir):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # copy the template directory to a new 'configuration' folder
+        destPath = os.path.join(temp_dir, 'configuration')
+        logger.info(f"Create new configuration in = {destPath}")
 
-    # copy the template directory to working area
-    destZip = os.path.basename(os.path.normpath(templateDir))
-    destPath = os.path.join(destDir, destZip)
-    logger.info("Create new configuration in = {}".format(destPath))
+        # copy the template directory
+        shutil.copytree(templateDir, destPath)
 
-    # remove directory if it already exists
-    if os.path.exists(destPath):
-        shutil.rmtree(destPath)
+        # find the standard configuration file and parse it
+        myConfigFile = os.path.join(destPath, "my_config.json")
+        with open(myConfigFile) as jsonFile:
+            myConfig = json.load(jsonFile)
 
-    # copy the template directory
-    shutil.copytree(templateDir, destPath)
+        # locate the section for chemical concentrations
+        chemSpeciesTag = "chemical species"
+        chemSpecies = myConfig[chemSpeciesTag]
+        logger.info(f"Replace chemSpecies = {chemSpecies}")
+        del myConfig[chemSpeciesTag]  # delete the existing section
 
-    # find the standard configuration file and parse it
-    myConfigFile = os.path.join(destPath, "my_config.json")
-    with open(myConfigFile) as jsonFile:
-        myConfig = json.load(jsonFile)
+        # set up dictionary of chemicals and initial values
+        chemValueDict = {}
+        temperature = 0.0
+        pressure = 0.0
+        for key, value in initValues.items():
+            if key == "temperature":
+                temperature = safeFloat(value[valueIndex])
+                continue
+            if key == "pressure":
+                pressure = safeFloat(value[valueIndex])
+                continue
 
-    # locate the section for chemical concentrations
-    chemSpeciesTag = "chemical species"
-    chemSpecies = myConfig[chemSpeciesTag]
-    logger.info("Replace chemSpecies = {}".format(chemSpecies))
-    del myConfig[chemSpeciesTag]     # delete the existing section
+            chemValueDict[key] = {f"initial value [{value[unitIndex]}]": value[valueIndex]}
 
-    # set up dictionary of chemicals and initial values
-    chemValueDict = {}
-    temperature = 0.0
-    pressure = 0.0
-    for key, value in initValues.items():
-        if (key == "temperature"):
-            temperature = safeFloat(value[valueIndex])
-            continue
-        if (key == "pressure"):
-            pressure = safeFloat(value[valueIndex])
-            continue
+        myConfig[chemSpeciesTag] = chemValueDict
 
-        chemValueDict[key] = {
-            "initial value [{}]".format(value[unitIndex]): value[valueIndex]}
+        # replace the values of temperature and pressure
+        envConditionsTag = "environmental conditions"
+        envConfig = myConfig[envConditionsTag]
+        envConfig["temperature"]["initial value [K]"] = temperature
+        envConfig["pressure"]["initial value [Pa]"] = pressure
 
-    myConfig[chemSpeciesTag] = chemValueDict
+        # save over the former json file
+        with open(myConfigFile, "w") as myConfigFp:
+            json.dump(myConfig, myConfigFp, indent=2)
 
-    # replace the values of temperature and pressure
-    envConditionsTag = "environmental conditions"
-    envConfig = myConfig[envConditionsTag]
-    envConfig["temperature"]["initial value [K]"] = temperature
-    envConfig["pressure"]["initial value [Pa]"] = pressure
+        # Create a zip file that contains the 'configuration' folder
+        zip_path = os.path.join(os.getcwd(), 'config.zip')
+        with zipfile.ZipFile(zip_path, 'w') as zipf:
+            for root, dirs, files in os.walk(temp_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    # Ensure the files are zipped under 'configuration' directory
+                    zipf.write(file_path, os.path.relpath(file_path, temp_dir))
 
-    # save over the former json file
-    with open(myConfigFile, "w") as myConfigFp:
-        json.dump(myConfig, myConfigFp, indent=2)
-
-    # compress the written directory as a zip file
-    shutil.make_archive(destPath, "zip",
-                        root_dir=destDir, base_dir=destZip)
-
-    # move into the created directory
-    shutil.move(destPath + ".zip", destPath)
-
-    return
+        logger.info(f"Configuration zipped to {zip_path}")
 
 
 # Main routine begins here.
 def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-    logger.info("{}".format(__file__))
-    logger.info("Start time: {}".format(datetime.datetime.now()))
+    logger.info(f"{__file__}")
+    logger.info(f"Start time: {datetime.datetime.now()}")
 
     # retrieve and parse the command-line arguments
     myArgs = getArgsDictionary(sys.argv[1:])
-    logger.info("Command line = {}".format(myArgs))
+    logger.info(f"Command line = {myArgs}")
 
     # set up the directories
     waccmDir = None
     if ("waccmDir" in myArgs):
         waccmDir = myArgs.get("waccmDir")
 
-    musicaDir = None
-    if ("musicaDir" in myArgs):
-        musicaDir = myArgs.get("musicaDir")
+    musicaDir = os.path.dirname(Examples.TS1.path)
+    template = os.path.dirname(Examples.TS1.path)
 
     # get the date-time to retrieve
     dateStr = None
@@ -423,56 +409,52 @@ def main():
     if ("longitude" in myArgs):
         lon = safeFloat(myArgs.get("longitude"))
 
-    retrieveWhen = datetime.datetime.strptime(
-        "{} {}".format(dateStr, timeStr), "%Y%m%d %H:%M")
+    when = datetime.datetime.strptime(
+        f"{dateStr} {timeStr}", "%Y%m%d %H:%M")
 
-    template = None
-    if ("template" in myArgs):
-        template = myArgs.get("template")
+    waccmFilename = f"f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{when.year:4d}-{when.month:02d}-{when.day:02}-00000.nc"
 
     # read and glean chemical species from WACCM and MUSICA
-    waccmChems = getWaccmSpecies(retrieveWhen, waccmDir)
+    waccmChems = getWaccmSpecies(waccmDir, waccmFilename)
     musicaChems = getMusicaSpecies(template)
 
     # create map of species common to both WACCM and MUSICA
     commonDict = getMusicaDictionary(waccmChems, musicaChems)
-    logger.info("Species in common are = {}".format(commonDict))
+    logger.info(f"Species in common are = {commonDict}")
     if (len(commonDict) == 0):
         logger.warning("There are no common species between WACCM and your MUSICA species.json file.")
 
     # Read named variables from WACCM model output.
-    logger.info("Retrieve WACCM conditions at ({} North, {} East)   when {}."
-                .format(lat, lon, retrieveWhen))
+    logger.info(f"Retrieve WACCM conditions at ({lat} North, {lon} East)   when {when}.")
     varValues = readWACCM(commonDict,
-                          lat, lon, retrieveWhen, waccmDir)
-    logger.info("Original WACCM varValues = {}".format(varValues))
+                          lat, lon, when, waccmDir, waccmFilename)
+    logger.info(f"Original WACCM varValues = {varValues}")
 
     # Perform any conversions needed, or derive variables.
     varValues = convertWaccm(varValues)
-    logger.info("Converted WACCM varValues = {}".format(varValues))
+    logger.info(f"Converted WACCM varValues = {varValues}")
 
-    if (True):
+    if (False):
         # Write CSV file for MusicBox initial conditions.
-        csvName = "{}/{}".format(musicaDir, "initial_conditions.csv")
+        csvName = os.path.join(musicaDir, "initial_conditions.csv")
         writeInitCSV(varValues, csvName)
 
-    if (True):
+    if (False):
         # Write JSON file for MusicBox initial conditions.
-        jsonName = "{}/{}".format(musicaDir, "initial_config.json")
+        jsonName = os.path.join(musicaDir, "initial_config.json")
         writeInitJSON(varValues, jsonName)
 
-    if (True and template is not None):
-        logger.info("Insert values into template {}".format(template))
-        insertIntoTemplate(varValues, template, musicaDir)
+    logger.info(f"Insert values into template {template}")
+    insertIntoTemplate(varValues, template)
 
-    logger.info("End time: {}".format(datetime.datetime.now()))
+    logger.info(f"End time: {datetime.datetime.now()}")
     sys.exit(0)     # no error
 
 
 if (__name__ == "__main__"):
     main()
 
-    logger.info("End time: {}".format(datetime.datetime.now()))
+    logger.info(f"End time: {datetime.datetime.now()}")
     sys.exit(0)     # no error
 
 

--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -229,7 +229,7 @@ def calcAirDensity(tempK, pressPa):
     GAS_CONSTANT = BOLTZMANN_CONSTANT * AVOGADRO_CONSTANT   # joules / Kelvin-mole
     airDensity = pressPa / (GAS_CONSTANT * tempK)           # moles / m3
 
-    return (airDensity)
+    return airDensity
 
 
 # set up indexes for the tuple
@@ -243,6 +243,10 @@ unitIndex = 2
 
 
 def convertWaccm(varDict):
+    # from the supporting documents
+    # https://agupubs.onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1029%2F2019MS001882&file=jame21103-sup-0001-2019MS001882+Text_SI-S01.pdf
+    soa_molecular_weight = 0.115 # kg mol-1
+    soa_density = 1770 # kg m-3
 
     # retrieve temperature and pressure from WACCM
     temperature = varDict["temperature"][valueIndex]
@@ -256,6 +260,10 @@ def convertWaccm(varDict):
         units = vTuple[unitIndex]
         if (units == "mol/mol"):
             varDict[key] = (vTuple[0], vTuple[valueIndex] * air_density, "mol m-3")
+        if (units == "kg/kg"):
+            # convert from kg/kb to mol / m3 by multiplying by air_density and dividing by molecular weight
+            # this only applies to soa species
+            varDict[key] = (vTuple[0], vTuple[valueIndex] * soa_density / soa_molecular_weight, "mol m-3")
 
     return (varDict)
 


### PR DESCRIPTION
- outputs the configuration in the current directory as config.zip
  - makes sure the zip file is compatible with music box interactive by placing it into a folder called `configuration`
-  Adds a conversion for soa species. Moleular weights and densities taken from [here](https://agupubs.onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1029%2F2019MS001882&file=jame21103-sup-0001-2019MS001882+Text_SI-S01.pdf)
- Converts from strings formatted with `.format` to [f strings](https://docs.python.org/3/tutorial/inputoutput.html#fancier-output-formatting)
- Removes the need to specify the TS1 and musica directories in favor of using the packages TS1 configuration so that command line usage is just `waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7`