### PR TITLE
Set species and rates configured in micm

### DIFF
--- a/src/acom_music_box/evolving_conditions.py
+++ b/src/acom_music_box/evolving_conditions.py
@@ -3,6 +3,8 @@ import os
 import re
 from .conditions import Conditions
 
+import logging
+logger = logging.getLogger(__name__)
 
 class EvolvingConditions:
     """
@@ -177,7 +179,17 @@ class EvolvingConditions:
             species_concentrations = {}
 
             for key in other_keys:
-                condition_type, label, unit = key.split('.')
+                parts = key.split('.')
+                condition_type, label, unit = None, None, None
+                if len(parts) == 3:
+                    condition_type, label, unit = parts
+                elif len(parts) == 2:
+                    condition_type, label = parts
+                else:
+                    error = f"Unexpected format in key: {key}"
+                    logger.error(error)
+                    raise ValueError(error)
+
                 if condition_type == 'CONC':
                     species_concentrations[label] = row[key]
                 else:

--- a/src/acom_music_box/music_box.py
+++ b/src/acom_music_box/music_box.py
@@ -263,8 +263,12 @@ class MusicBox:
         """
         ordered_rate_constants = np.zeros(len(rate_constant_ordering), dtype=np.float64)
 
-        for rate_label, value in curr_conditions.reaction_rates.items():
-            ordered_rate_constants[rate_constant_ordering[rate_label]] = value
+        for rate_label, _ in rate_constant_ordering.items():
+            if rate_label not in curr_conditions.reaction_rates:
+                logger.warning(f"Reaction rate '{rate_label}' not found in current conditions.")
+                continue
+            else:
+                ordered_rate_constants[rate_constant_ordering[rate_label]] = curr_conditions.reaction_rates[rate_label]
 
         return ordered_rate_constants
 
@@ -285,7 +289,11 @@ class MusicBox:
         """
         concentrations = np.zeros(len(species_constant_ordering), dtype=np.float64)
 
-        for species, value in curr_conditions.species_concentrations.items():
-            concentrations[species_constant_ordering[species]] = value
+        for species, _ in species_constant_ordering.items():
+            if species not in curr_conditions.species_concentrations:
+                logger.warning(f"Species '{species}' not found in current conditions.")
+                continue
+            else:
+                concentrations[species_constant_ordering[species]] = curr_conditions.species_concentrations[species]
 
         return concentrations


### PR DESCRIPTION
Closes #176. Greg's group had files that tested a condition that we didn't account for: when the conditions files contain values for more rates and species than configured with micm. We can support this. The corrected configurations for #176 are attached

[config 2.zip](https://github.com/user-attachments/files/17366021/config.2.zip)
[config 31.zip](https://github.com/user-attachments/files/17366022/config.31.zip)
[config 32.zip](https://github.com/user-attachments/files/17366023/config.32.zip)
