### PR TITLE
Added N2, O2, and Argon calculated concentrations to the WACCM initial conditions

### DIFF
--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -220,6 +220,17 @@ def readWACCM(waccmMusicaDict, latitude, longitude,
     return (musicaDict)
 
 
+# Add molecular Nitrogen, Oxygen, and Argon to dictionary.
+# varValues = already read from WACCM, contains (name, concentration, units)
+# return varValues with N2, O2, and Ar added
+def addStandardGases(varValues):
+    varValues["N2"] = ("N2", 0.78084, "mol/mol")    # standard fraction by volume
+    varValues["O2"] = ("O2", 0.20946, "mol/mol")
+    varValues["Ar"] = ("Ar", 0.00934, "mol/mol")
+
+    return(varValues)
+
+
 # set up indexes for the tuple
 musicaIndex = 0
 valueIndex = 1
@@ -432,6 +443,9 @@ def main():
     varValues = readWACCM(commonDict,
                           lat, lon, when, waccmDir, waccmFilename)
     logger.info(f"Original WACCM varValues = {varValues}")
+
+    # add molecular Nitrogen, Oxygen, and Argon
+    varValues = addStandardGases(varValues)
 
     # Perform any conversions needed, or derive variables.
     varValues = convertWaccm(varValues)


### PR DESCRIPTION
The last few columns of the CSV diagnostic file look like this:

```
soa4_a2 [mol m-3]	soa5_a1 [mol m-3]	soa5_a2 [mol m-3]	N2 [mol m-3]	O2 [mol m-3]	Ar [mol m-3]
1.84E-07	3.54E-05	6.02E-08	30.69344699	8.233504183	0.367138972
```

The chemical units are now given in [brackets] in the CSV column titles and JSON.