### PR TITLE
adding matplotlib plotting support with a tooltip hover

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
   "colorlog",
   "pandas",
   "tqdm",
-  "netcdf4"
+  "netcdf4",
+  "matplotlib",
+  "mplcursors"
 ]
 
 [project.urls]

--- a/src/acom_music_box/main.py
+++ b/src/acom_music_box/main.py
@@ -61,8 +61,8 @@ def parse_arguments():
         '--plot-tool',
         type=str,
         choices=['gnuplot', 'matplotlib'],
-        default='gnuplot',
-        help='Choose plotting tool: gnuplot or matplotlib (default: gnuplot).'
+        default='matplotlib',
+        help='Choose plotting tool: gnuplot or matplotlib (default: matplotlib).'
     )
     return parser.parse_args()
 

--- a/src/acom_music_box/main.py
+++ b/src/acom_music_box/main.py
@@ -150,7 +150,7 @@ def plot_with_matplotlib(data, species_list):
     # Customize the annotation format
     @cursor.connect("add")
     def on_add(sel):
-        sel.annotation.set_text(f'Time: {sel.target[0]:.2f}\nConcentration: {sel.target[1]:.2f}')
+        sel.annotation.set_text(f'Time: {sel.target[0]:.2f}\nConcentration: {sel.target[1]:1.2e}')
 
     plt.show()
 

--- a/tests/integration/test_analytical.py
+++ b/tests/integration/test_analytical.py
@@ -69,7 +69,6 @@ class TestAnalytical:
             analytical_concentrations.append([A_conc, B_conc, C_conc])
             curr_time += time_step
 
-        print(analytical_concentrations)
         # asserts concentrations
         for i in range(len(model_concentrations)):
             assert math.isclose(

--- a/tests/integration/test_analytical.py
+++ b/tests/integration/test_analytical.py
@@ -69,6 +69,7 @@ class TestAnalytical:
             analytical_concentrations.append([A_conc, B_conc, C_conc])
             curr_time += time_step
 
+        print(analytical_concentrations)
         # asserts concentrations
         for i in range(len(model_concentrations)):
             assert math.isclose(


### PR DESCRIPTION
Closes #269

Adds an option to choose the plotting backend (gnuplot or matplotlib). Also adds tooltips to matplotlib

It can be used like this: `music_box -e Analytical --plot CONC.A,CONC.B,CONC.C --plot-tool matplotlib -o/dev/null`

<img width="1112" alt="Screenshot 2024-10-16 at 9 20 12 AM" src="https://github.com/user-attachments/assets/c3e1a184-1672-4e36-8139-79459ca15352">
