### PR TITLE
Add temporary values for O2, N2, H2O for TS1 example

### DIFF
--- a/src/acom_music_box/examples/configs/ts1/my_config.json
+++ b/src/acom_music_box/examples/configs/ts1/my_config.json
@@ -411,6 +411,15 @@
     },
     "TEPOMUC": {
       "initial value [mol m-3]": 1.86716E-11
+    },
+    "O2": {
+      "initial value [mol m-3]": 8.368900382
+    },
+    "N2": {
+      "initial value [mol m-3]": 31.08448713
+    },
+    "H2O": {
+      "initial value [mol m-3]": 1.195557197
     }
   },
   "environmental conditions": {


### PR DESCRIPTION
Temporarily updates TS1 example to include initial conditions for O2, N2, H2O based on rough estimates of 21%, 78%, and 3% of total air density, pending comprehensive updates to conditions from Sancy.