### PR TITLE
changing how output works, adding tests for output

### DIFF
--- a/src/acom_music_box/main.py
+++ b/src/acom_music_box/main.py
@@ -38,8 +38,9 @@ def parse_arguments():
     )
     parser.add_argument(
         '--output-format',
-        choices=['csv', 'netcdf'],
-        help="Specify output format: 'csv' (default) or 'netcdf'."
+        choices=['csv', 'netcdf', 'terminal'],
+        default='terminal',
+        help="Specify output format: 'terminal' (default), 'csv', or 'netcdf'."
     )
     parser.add_argument(
         '-v', '--verbose',

--- a/tests/integration/test_executable_data_output.py
+++ b/tests/integration/test_executable_data_output.py
@@ -1,0 +1,50 @@
+import subprocess
+import os
+import glob
+import pytest
+import tempfile
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield tmpdirname
+
+def test_print_results_to_terminal(temp_dir):
+    result = subprocess.run(['music_box', '-e', 'Analytical'], capture_output=True, text=True, cwd=temp_dir)
+    assert len(result.stdout) > 0
+
+def test_create_netcdf_with_timestamp(temp_dir):
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'netcdf'], cwd=temp_dir)
+    assert glob.glob(os.path.join(temp_dir, "music_box_*.nc"))
+
+def test_create_csv_with_timestamp(temp_dir):
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'csv'], cwd=temp_dir)
+    assert glob.glob(os.path.join(temp_dir, "music_box_*.csv"))
+
+def test_create_named_csv(temp_dir):
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'csv', '-o', 'out.csv'], cwd=temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, "out.csv"))
+
+def test_create_named_netcdf(temp_dir):
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'netcdf', '-o', 'out.nc'], cwd=temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, "out.nc"))
+
+def test_create_directory_and_named_netcdf(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "results"), exist_ok=True)
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'netcdf', '-o', 'results/out.nc'], cwd=temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, "results/out.nc"))
+
+def test_create_directory_and_named_csv(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "results"), exist_ok=True)
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'csv', '-o', 'results/out.csv'], cwd=temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, "results/out.csv"))
+
+def test_create_directory_and_timestamped_csv(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "results"), exist_ok=True)
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'csv', '-o', 'results/'], cwd=temp_dir)
+    assert glob.glob(os.path.join(temp_dir, "results/music_box_*.csv"))
+
+def test_create_directory_and_timestamped_netcdf(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "results"), exist_ok=True)
+    subprocess.run(['music_box', '-e', 'Analytical', '--output-format', 'netcdf', '-o', 'results/'], cwd=temp_dir)
+    assert glob.glob(os.path.join(temp_dir, "results/music_box_*.nc"))


### PR DESCRIPTION
Closes #237 

- Adds 'terminal' as an output format
- Uses the date time to create a file name
- Supports all of these use cases and creates unit tests for these:

```
# should print results to terminal
music_box -e Analytical

# should create a filename that is similar to music_box_20241108_093604.nc in the current directory
music_box -e Analytical --output-format netcdf

# should create a filename that is similar to music_box_20241108_093604.csv in the current directory
music_box -e Analytical --output-format csv

# should create a file named out.csv in the current directory
music_box -e Analytical --output-format csv -o out.csv

# should create a named out.nc in the current directory
music_box -e Analytical --output-format netcdf -o out.nc

# should create directory results and write out.nc into that directory
music_box -e Analytical --output-format netcdf -o results/out.nc

# should create directory results and write out.csv into that directory
music_box -e Analytical --output-format csv -o results/out.csv

# should create directory results and write a file with a name similar to music_box_20241108_093604.csv
music_box -e Analytical --output-format csv -o results/

# should create directory results and write a file with a name similar to music_box_20241108_093604.nc
music_box -e Analytical --output-format netcdf -o results/
```