### PR TITLE
Updated CI_Tests.yml to setup codecov

### DIFF
--- a/.github/workflows/CI_Tests.yml
+++ b/.github/workflows/CI_Tests.yml
@@ -29,9 +29,6 @@ jobs:
     - name: Install this package
       run: pip install -e '.[dev]'
     
-    - name: Run pytest
-      run: pytest
-    
     - name: Run the smoke tests
       run: |
         music_box -c src/acom_music_box/examples/configs/analytical/my_config.json -o output.csv
@@ -40,7 +37,7 @@ jobs:
         waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7
     
     - name: Run tests and generate coverage reports
-      run: pytest --cov .
+      run: pytest --cov tests/
     
     - name: Upload coverage reports to codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/CI_Tests.yml
+++ b/.github/workflows/CI_Tests.yml
@@ -29,13 +29,6 @@ jobs:
     - name: Install this package
       run: pip install -e '.[dev]'
     
-    - name: Run the smoke tests
-      run: |
-        music_box -c src/acom_music_box/examples/configs/analytical/my_config.json -o output.csv
-        music_box -e Analytical -o output.csv
-        music_box -e Analytical -o output.csv -vv --color-output
-        waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7
-    
     - name: Run tests and generate coverage reports
       run: pytest --cov tests/
     
@@ -45,6 +38,13 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.info
         fail_ci_if_error: false
+        
+    - name: Run the smoke tests
+      run: |
+        music_box -c src/acom_music_box/examples/configs/analytical/my_config.json -o output.csv
+        music_box -e Analytical -o output.csv
+        music_box -e Analytical -o output.csv -vv --color-output
+        waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7
 
     - name: Check for config.zip
       if: runner.os != 'Windows'

--- a/.github/workflows/CI_Tests.yml
+++ b/.github/workflows/CI_Tests.yml
@@ -33,11 +33,11 @@ jobs:
       run: pytest --cov tests/
     
     - name: Upload coverage reports to codecov
+      if: runner.os == 'Linux'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.info
-        fail_ci_if_error: false
         
     - name: Run the smoke tests
       run: |

--- a/.github/workflows/CI_Tests.yml
+++ b/.github/workflows/CI_Tests.yml
@@ -38,6 +38,16 @@ jobs:
         music_box -e Analytical -o output.csv
         music_box -e Analytical -o output.csv -vv --color-output
         waccmToMusicBox waccmDir="./sample_waccm_data" date="20240904" time="07:00" latitude=3.1 longitude=101.7
+    
+    - name: Run tests and generate coverage reports
+      run: pytest --cov .
+    
+    - name: Upload coverage reports to codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.info
+        fail_ci_if_error: false
 
     - name: Check for config.zip
       if: runner.os != 'Windows'

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ MusicBox: A MUSICA model for boxes and columns.
 
 [![License](https://img.shields.io/github/license/NCAR/music-box.svg)](https://github.com/NCAR/music-box/blob/main/LICENSE)
 [![CI Status](https://github.com/NCAR/music-box/actions/workflows/CI_Tests.yml/badge.svg)](https://github.com/NCAR/music-box/actions/workflows/CI_Tests.yml)
-<!-- verify codecov badge link -->
-[![codecov](https://codecov.io/gh/NCAR/music-box/branch/main/graph/badge.svg?token=ATGO4DKTMY)](https://codecov.io/gh/NCAR/music-box)
+[![codecov](https://codecov.io/github/NCAR/music-box/graph/badge.svg?token=OR7JEQJSRQ)](https://codecov.io/github/NCAR/music-box)
 [![PyPI version](https://badge.fury.io/py/acom-music-box.svg)](https://badge.fury.io/py/acom-music-box)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14008358.svg)](https://doi.org/10.5281/zenodo.14008358)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ MusicBox: A MUSICA model for boxes and columns.
 
 [![License](https://img.shields.io/github/license/NCAR/music-box.svg)](https://github.com/NCAR/music-box/blob/main/LICENSE)
 [![CI Status](https://github.com/NCAR/music-box/actions/workflows/CI_Tests.yml/badge.svg)](https://github.com/NCAR/music-box/actions/workflows/CI_Tests.yml)
+<!-- verify codecov badge link -->
+[![codecov](https://codecov.io/gh/NCAR/music-box/branch/main/graph/badge.svg?token=ATGO4DKTMY)](https://codecov.io/gh/NCAR/music-box)
 [![PyPI version](https://badge.fury.io/py/acom-music-box.svg)](https://badge.fury.io/py/acom-music-box)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14008358.svg)](https://doi.org/10.5281/zenodo.14008358)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,6 @@ waccmToMusicBox = "acom_music_box.tools.waccmToMusicBox:main"
 [project.optional-dependencies]
 dev = [
   "pytest",
-  "pytest-mock"
+  "pytest-mock",
+  "pytest-cov"
 ]


### PR DESCRIPTION
This PR sets up Codecov to generate coverage reports and display the coverage on the README using the Codecov badge.
 I've removed `name: Run pytest` job as codecov already runs tests and running pytest separately would be redundant.

This PR :
- Makes changes to the CI tests to upload coverage reports to codecov
- Adds the codecov badge to the README to show test coverage 
- Closes issue [#275](https://github.com/NCAR/music-box/issues/275)
