### PR TITLE
Removed creation of config.zip with a conditional flag.

### DIFF
--- a/src/acom_music_box/tools/waccmToMusicBox.py
+++ b/src/acom_music_box/tools/waccmToMusicBox.py
@@ -424,6 +424,7 @@ def main():
     # get the requested (diagnostic) output
     outputCSV = False
     outputJSON = False
+    insertIntoConfig = False
     if ("output" in myArgs):
         # parameter is like: output=CSV,JSON
         outputFormats = myArgs.get("output").split(",")
@@ -471,8 +472,9 @@ def main():
         logger.info(f"jsonName = {jsonName}")
         writeInitJSON(varValues, jsonName)
 
-    logger.info(f"Insert values into template {template}")
-    insertIntoTemplate(varValues, template)
+    if (insertIntoConfig):
+        logger.info(f"Insert values into template {template}")
+        insertIntoTemplate(varValues, template)
 
     logger.info(f"End time: {datetime.datetime.now()}")
 

--- a/tests/integration/test_waccm_conversion.py
+++ b/tests/integration/test_waccm_conversion.py
@@ -48,4 +48,3 @@ def test_waccm_to_music_box_conversion(temp_dir):
     # Check if the output files are created
     assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_conditions.csv"))
     assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_config.json"))
-    assert os.path.exists(os.path.join(temp_dir, "config.zip"))


### PR DESCRIPTION
We no longer need to insert initial chemical values into the JSON, because that method of initialization has been superseded by the new method of reading initial concentrations from a CSV file (created by waccmToMusicBox.py).

I have bypassed the call to insertIntoTemplate() in the code because it is complicated and I thought we might need that logic again. I will remove insertIntoTemplate() entirely if the reviewers so recommend.
