### PR TITLE
Fix: Update installation instructions to use correct PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Copyright (C) 2020 National Science Foundation - National Center for Atmospheric
 
 # Installation
 ```
-pip install acom_music_box
+pip install acom-music-box
 ```
 
 # Command line tool


### PR DESCRIPTION
This PR resolves Issue #309.

- Updated the installation instructions in README.md to use the correct PyPI package name.
- Changed `pip install acom_music_box` to `pip install acom-music-box`.
- This ensures that users can install the package successfully via pip.
