### PR TITLE
Update binder links to main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MusicBox: A MUSICA model for boxes and columns.
 [![codecov](https://codecov.io/github/NCAR/music-box/graph/badge.svg?token=OR7JEQJSRQ)](https://codecov.io/github/NCAR/music-box)
 [![PyPI version](https://badge.fury.io/py/acom-music-box.svg)](https://badge.fury.io/py/acom-music-box)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14008358.svg)](https://doi.org/10.5281/zenodo.14008358)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/music-box/binder_setup)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/music-box/HEAD)
 
 Copyright (C) 2020 National Science Foundation - National Center for Atmospheric Research
 

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -11,9 +11,9 @@ Interactive Notebooks
 The MusicBox repository utilizes `Binder <https://mybinder.readthedocs.io/en/latest/index.html#>`_ to allow users to interact with the tutorial notebooks on a `JupyterHub <https://jupyter.org/hub>`_.
 Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
 
-1. `a basic MusicBox workflow <https://mybinder.org/v2/gh/NCAR/music-box/3ba8be9dc0539a3b44455d95d306c0b97d74bc85?urlpath=lab%2Ftree%2Ftutorial%2F1.%20basic_workflow.ipynb>`_
-2. `overriding mechanisms <https://mybinder.org/v2/gh/NCAR/music-box/3ba8be9dc0539a3b44455d95d306c0b97d74bc85?urlpath=lab%2Ftree%2Ftutorial%2F2.%20override_mechanism.ipynb>`_
-3. `loading custom box models <https://mybinder.org/v2/gh/NCAR/music-box/3ba8be9dc0539a3b44455d95d306c0b97d74bc85?urlpath=lab%2Ftree%2Ftutorial%2F3.%20loading_custom_box_models.ipynb>`_
+1. `a basic MusicBox workflow <https://mybinder.org/v2/gh/NCAR/music-box/d2e3ce8df4d1e8b80bf1d240876a31ba6e3e9a4d?urlpath=lab%2Ftree%2Ftutorials%2F1.%20basic_workflow.ipynb>`_
+2. `overriding mechanisms <https://mybinder.org/v2/gh/NCAR/music-box/d2e3ce8df4d1e8b80bf1d240876a31ba6e3e9a4d?urlpath=lab%2Ftree%2Ftutorials%2F2.%20override_mechanism.ipynb>`_
+3. `loading custom box models <https://mybinder.org/v2/gh/NCAR/music-box/d2e3ce8df4d1e8b80bf1d240876a31ba6e3e9a4d?urlpath=lab%2Ftree%2Ftutorials%2F3.%20loading_custom_box_models.ipynb>`_
 
 Github
 --------

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -17,11 +17,11 @@ Each of the links below will open a JupyterHub set up with all necessary depende
 
 Github
 --------
-For users that wish to directly download local copies of the tutorial notebooks, they are each made available on our Github within the `tutorials <https://github.com/NCAR/music-box/tree/main/tutorial>`_ folder. Each notebook is also linked below:
+For users that wish to directly download local copies of the tutorial notebooks, they are each made available on our Github within the `tutorials <https://github.com/NCAR/music-box/tree/main/tutorials>`_ folder. Each notebook is also linked below:
 
-1. `a basic MusicBox workflow <https://github.com/NCAR/music-box/blob/main/tutorial/1.%20basic_workflow.ipynb>`_
-2. `overriding mechanisms <https://github.com/NCAR/music-box/blob/main/tutorial/2.%20override_mechanism.ipynb>`_
-3. `loading custom box models <https://github.com/NCAR/music-box/blob/main/tutorial/3.%20loading_custom_box_models.ipynb>`_
+1. `a basic MusicBox workflow <https://github.com/NCAR/music-box/blob/main/tutorials/1.%20basic_workflow.ipynb>`_
+2. `overriding mechanisms <https://github.com/NCAR/music-box/blob/main/tutorials/2.%20override_mechanism.ipynb>`_
+3. `loading custom box models <https://github.com/NCAR/music-box/blob/main/tutorials/3.%20loading_custom_box_models.ipynb>`_
 
 
 Web View


### PR DESCRIPTION
binder links from the previous PR were set to reference the last branch that has since been deleted. the new readme badge and tutorial webpage links now reference the binder created from the main repository. 