### PR TITLE
Add missing hyperlink to override mechanism tutorial

### DIFF
--- a/tutorials/2. override_mechanism.ipynb
+++ b/tutorials/2. override_mechanism.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "## 1. Creating the Mechanism and Box Model\n",
     "\n",
-    "This is simply a copy of the first half of the Basic Workflow Tutorial to set up the mechanism for overriding."
+    "This is simply a copy of the first half of the [Basic Workflow Tutorial](1.%20basic_workflow.ipynb) to set up the mechanism for overriding."
    ]
   },
   {


### PR DESCRIPTION
I noticed that there was a missing hyperlink in the 2nd tutorial, so this is just a quick pull request to address that.