### PR TITLE
Fix typo in ML tutorial

### DIFF
--- a/tutorials/2. override_mechanism.ipynb
+++ b/tutorials/2. override_mechanism.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "## 1. Creating the Mechanism and Box Model\n",
     "\n",
-    "This is simply a copy of the first half of the Basic Workflow Tutorial to set up the mechanism for overriding."
+    "This is simply a copy of the first half of the [Basic Workflow Tutorial](1.%20basic_workflow.ipynb) to set up the mechanism for overriding."
    ]
   },
   {

--- a/tutorials/4. machine_learning.ipynb
+++ b/tutorials/4. machine_learning.ipynb
@@ -804,10 +804,9 @@
     "## 5. Normalizing the Concentrations\n",
     "\n",
     "For many ML models, including linear regression, normalizing your data will ensure that each of the input and output features are weighted equally when they are not on the same scale initially.</br>\n",
-    "To normalize the data, two [<i>MinMaxScaler()</i>](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html) objects are created, one for the dependent dependent concentration variables, and one for the independent concentration variables.</br>\n",
+    "To normalize the data, two [<i>MinMaxScaler()</i>](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html) objects are created, one for the dependent concentration variables, and one for the independent concentration variables.</br>\n",
     "These scalers can be fitted and alter the training data concentration columns in place with its <i>fit_transform()</i> function by taking in a column that is used to calcuate the normalized values.</br>\n",
     "However, the testing data is scaled with the <i>transform()</i> function since you never want to fit on your testing data, as it will lead to data leakages, causing the model to overfit.</br>\n",
-    "It should be noted that the future columns are normalized based on the original concentration columns so that the normalization is kept consistent between the original column and the future time step column.</br>\n",
     "All the unscaled and scaled DataFrames are then displayed so that you can see what the normalization does to the concentration values."
    ]
   },


### PR DESCRIPTION
I noticed a minor type in the machine learning tutorial, so this pull request simply amends that issue.