### PR TITLE
385 plotting fails - fixed

### DIFF
--- a/src/acom_music_box/plot_output.py
+++ b/src/acom_music_box/plot_output.py
@@ -63,7 +63,8 @@ class PlotOutput:
         Format the species list for plotting.
 
         This method formats the species list for plotting by adding the 'CONC.' prefix
-        to each species name if it is not already present.
+        to each species name if it is not already present, and the default units
+        if no units are already specified.
 
         Parameters
         ----------
@@ -83,6 +84,8 @@ class PlotOutput:
                 species = species.strip()
                 if 'CONC.' not in species:
                     species = f'CONC.{species}'
+                if (species.count('.') < 2):
+                    species = f'{species}.{self.output_unit}'
                 plot_list.append(species)
 
         return plot_list

--- a/tests/integration/test_carbon_bond_5.py
+++ b/tests/integration/test_carbon_bond_5.py
@@ -98,8 +98,8 @@ class TestCarbonBond5:
         ]
 
         # append units to those chemicals for CSV comparison
-        concUnits = ".mol m-3"
-        concs_to_test = [conc + concUnits for conc in concs_to_test]
+        concUnits = "mol m-3"
+        concs_to_test = [f"{conc}.{concUnits}" for conc in concs_to_test]
 
         model_output_header = model_output[0]
         test_output_header = test_output[0]
@@ -127,8 +127,8 @@ class TestCarbonBond5:
                 ), f"Arrays differ at index ({i}, {j}, species {concs_to_test[j]})"
 
         # test plotting those calculated results
-        args = argparse.Namespace(example='CB5', plot=['CH4.mol m-3'],
-            output=["out.nc"], plot_output_unit='mol m-3')
+        args = argparse.Namespace(example='CB5', plot=['CH4'],
+            output=["out.nc"], plot_output_unit=concUnits)
         plot_output = PlotOutput(df, args)
         plot_output.plot()
 

--- a/tests/unit/test_plot_output.py
+++ b/tests/unit/test_plot_output.py
@@ -13,9 +13,9 @@ class TestPlotOutput(unittest.TestCase):
         # Set up a sample DataFrame and arguments for testing
         self.df = pd.DataFrame({
             'time.s': [0, 1, 2],
-            'CONC.A': [1, 2, 3],
-            'CONC.B': [4, 5, 6],
-            'CONC.C': [7, 8, 9],
+            'CONC.A.mol m-3': [1, 2, 3],
+            'CONC.B.mol m-3': [4, 5, 6],
+            'CONC.C.mol m-3': [7, 8, 9],
             'ENV.temperature.K': [298.15, 298.15, 298.15],
             'ENV.pressure.Pa': [101325, 101325, 101325]
         })
@@ -23,7 +23,7 @@ class TestPlotOutput(unittest.TestCase):
     def test_format_species_list(self):
         args = Namespace(plot=['A', 'B'], plot_output_unit='mol m-3')
         plot_output = PlotOutput(self.df, args)
-        expected_list = [['CONC.A'], ['CONC.B']]
+        expected_list = [['CONC.A.mol m-3'], ['CONC.B.mol m-3']]
         self.assertEqual(plot_output.species_list, expected_list)
 
         args = Namespace(plot=['CONC.A', 'CONC.B'], plot_output_unit='mol m-3')


### PR DESCRIPTION
This PR fixes MusicBox issue #385: https://github.com/NCAR/music-box/issues/385

I set up the integration test to exercise plotting and catch failure. The convention adopted for chemical species within the Python code was established as CONC.Chemical.units, and a few instances of species had not been converted.

The calling sequence for plotting remains the same:
music_box -e CB5 --plot CH4 -o out.nc --verbose