### PR TITLE
450 documentation tools

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -149,18 +149,31 @@ music_box -e TS1 --plot O3 --plot-output-unit ppb
 
 ## Tool: waccmToMusicBox
 
-Extract chemical species concentrations from WACCM or WRF-Chem output and write them as MusicBox initial conditions:
+This tool allows you to extract chemical species concentrations from WACCM or WRF-Chem model output and write them as MusicBox initial conditions.
+Use the built-in help to display all options including template configurations and multiple output formats:
 
 ```bash
-waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7
+waccmToMusicBox --help
+```
+
+You may specify a single point in space and date-time by passing single values to date, time, latitude, and longitude.
+Altitude defaults to the surface.
+You may also specify a rectangle or cube by specifying multiple values for latitude, longitude, and altitude.
+If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
+Use a lat-lon variable (PBLH) to bound the vertical dimension at a specific height.
+
+```bash
+waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 -verbose
 
 waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```
 
-For advanced options including template configs and multiple output formats:
+waccmToMusicBox uses MUSICA configuration file to create a list of common chemical species between MusicBox and WACCM or WRF-Chem.
+The default configuration file is in the ts1 example because that example has many species.
+Use the --template parameter to specify your own configuration file (usually my_config.json).
 
 ```bash
-waccmToMusicBox --help
+waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --musicaDir ~/MusicBox/WRF-Chem/csvJsonDir --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output CSV,JSON --verbose
 ```
 
 ## Development

--- a/python/README.md
+++ b/python/README.md
@@ -152,7 +152,7 @@ music_box -e TS1 --plot O3 --plot-output-unit ppb
 Extract chemical species concentrations from WACCM or WRF-Chem output and write them as MusicBox initial conditions:
 
 ```bash
-waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20240904" --time "07:00" --latitude 3.1 --longitude 101.7
+waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7
 
 waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -159,8 +159,8 @@ waccmToMusicBox --help
 You may specify a single point in space and date-time by passing single values to date, time, latitude, and longitude.
 Altitude defaults to the surface.
 You may also specify a rectangle or cube by specifying multiple values for latitude, longitude, and altitude.
-If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
 Use a lat-lon variable (PBLH) to bound the vertical dimension at a specific height.
+If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
 
 ```bash
 waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 -verbose
@@ -174,6 +174,8 @@ Use the --template parameter to specify your own configuration file (usually my_
 
 ```bash
 waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --musicaDir ~/MusicBox/WRF-Chem/csvJsonDir --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output CSV,JSON --verbose
+
+python3 waccmToMusicBox.py --waccmDir ~/MusicBox/WACCM/model-output --musicaDir ~/MusicBox/WACCM/csvJsonDir --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ../../../examples/ts1 --output CSV,JSON --verbose -v
 ```
 
 ## Development

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -680,7 +680,7 @@ def main():
 
             # read and glean chemical species from WACCM and MUSICA
             waccmChems = getWaccmSpecies(modelDir, waccmFilename)
-            musicaChems = getMusicaSpecies(template)
+            musicaChems = getMusicaSpecies(templateFile)
 
             # create map of species common to both WACCM and MUSICA
             commonDict = getMusicaDictionary(modelType, waccmChems, musicaChems)

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -122,6 +122,7 @@ def parse_arguments():
     parser.add_argument(
         '--output',
         type=str,
+        default="CSV",
         help="Format(s) for writing the initial conditions: CSV,JSON"
     )
     return parser.parse_args()


### PR DESCRIPTION
The new documentation is in the README file within the **python** directory. Please let me know if the amount of explanation and the number of script examples are about right.

Look under this section:
**Tool: waccmToMusicBox**

There is also a bug fix having to do with the template file/directory.