### PR TITLE
454 waccm instructions and integration test

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -175,11 +175,11 @@ The default configuration file is in the ts1 example because that example has ma
 Use the --template parameter to specify your own configuration file (usually my_config.json).
 
 ```bash
-waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --stride 3 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ./examples/ts1 --output evolving.csv --output evolving.json --verbose
+waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --stride 3 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ./examples/ts1 --output evolving_conditions.csv --verbose
 ```
 
 ```bash
-waccmToMusicBox --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ./examples/ts1 --output conditions/evolving.csv -o conditions/evolving.json --verbose -v
+waccmToMusicBox --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ./examples/ts1 --output conditions/evolving_conditions.csv --verbose -v
 ```
 
 ## Development

--- a/python/README.md
+++ b/python/README.md
@@ -173,9 +173,9 @@ The default configuration file is in the ts1 example because that example has ma
 Use the --template parameter to specify your own configuration file (usually my_config.json).
 
 ```bash
-waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --musicaDir ~/MusicBox/WRF-Chem/csvJsonDir --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output CSV,JSON --verbose
+waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output evolving.csv --output evolving.json --verbose
 
-python3 waccmToMusicBox.py --waccmDir ~/MusicBox/WACCM/model-output --musicaDir ~/MusicBox/WACCM/csvJsonDir --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ../../../examples/ts1 --output CSV,JSON --verbose -v
+python3 waccmToMusicBox.py --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ../../../examples/ts1 --output conditions/evolving.csv -o conditions/evolving.json --verbose -v
 ```
 
 ## Development

--- a/python/README.md
+++ b/python/README.md
@@ -164,7 +164,9 @@ If you request two date-time pairs, the tool will create evolving conditions ove
 
 ```bash
 waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 --verbose
+```
 
+```bash
 waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```
 
@@ -174,7 +176,9 @@ Use the --template parameter to specify your own configuration file (usually my_
 
 ```bash
 waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output evolving.csv --output evolving.json --verbose
+```
 
+```bash
 python3 waccmToMusicBox.py --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ../../../examples/ts1 --output conditions/evolving.csv -o conditions/evolving.json --verbose -v
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -163,7 +163,7 @@ Use a lat-lon variable (PBLH) to bound the vertical dimension at a specific heig
 If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
 
 ```bash
-waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 -verbose
+waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 --verbose
 
 waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -175,11 +175,11 @@ The default configuration file is in the ts1 example because that example has ma
 Use the --template parameter to specify your own configuration file (usually my_config.json).
 
 ```bash
-waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ../../../examples/ts1 --output evolving.csv --output evolving.json --verbose
+waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20250822 --time 18:00,05:00 --stride 3 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --altitude surface,PBLH --template ./examples/ts1 --output evolving.csv --output evolving.json --verbose
 ```
 
 ```bash
-python3 waccmToMusicBox.py --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ../../../examples/ts1 --output conditions/evolving.csv -o conditions/evolving.json --verbose -v
+waccmToMusicBox --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ./examples/ts1 --output conditions/evolving.csv -o conditions/evolving.json --verbose -v
 ```
 
 ## Development

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -121,8 +121,7 @@ def parse_arguments():
         default=[],
         help=("Path to save the initial/evolving conditions, including the file name."
               + "\nIf not provided, result will be printed to the console."
-              + "\nUse the file extension to specify the output format: .csv or .json"
-              + "\nRepeat this argument to write output in multiple formats."
+              + "\nUse the file extension to specify the output format: .csv"
         )
     )
     return parser.parse_args()

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -357,11 +357,19 @@ def convertWaccm(varDict):
     # https://agupubs.onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1029%2F2019MS001882&file=jame21103-sup-0001-2019MS001882+Text_SI-S01.pdf
     soa_molecular_weight = 0.115  # kg mol-1
     soa_density = 1770  # kg m-3
+    hPaToPa = 100
 
     # retrieve temperature and pressure from WACCM
     temperature = varDict["temperature"][valueIndex][0]
+    tempUnits = varDict["temperature"][unitIndex]
+
     pressure = varDict["pressure"][valueIndex][0]
-    logger.info(f"temperature = {temperature} K   pressure = {pressure} Pa")
+    pressUnits = varDict["pressure"][unitIndex]
+    if (pressUnits == "hPa"):
+        pressure *= hPaToPa
+        pressUnits = "Pa"
+    logger.info(f"temperature = {temperature} {tempUnits}   pressure = {pressure} {pressUnits}")
+
     air_density = calculate_air_density(temperature, pressure)
     logger.info(f"air density = {air_density} mol m-3")
 
@@ -375,6 +383,9 @@ def convertWaccm(varDict):
             # soa species only
             varDict[key] = (vTuple[0], "mol m-3",
                             [vTuple[valueIndex][0] * soa_density / soa_molecular_weight])
+        if (units == "hPa"):
+            varDict[key] = (vTuple[0], "Pa",
+                            [vTuple[valueIndex][0] * hPaToPa])
 
     return (varDict)
 

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -751,6 +751,14 @@ def main():
         # loop through the requested output files/formats
         for output in myArgs.output:
             logger.info(f"Writing output to {output} ...")
+
+            # ensure that any directories already exist
+            dir_path = os.path.dirname(output)
+            if dir_path and not os.path.exists(dir_path):
+                os.makedirs(dir_path, exist_ok=True)
+                logger.info(f"Created directory: {dir_path}")
+
+            # file extension specifies the output type
             nameonly, extension = os.path.splitext(output)
             extension = extension.replace('.', '').lower()
 

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -47,7 +47,7 @@ def setup_logging(verbosity):
 # Parse the command-line arguments in this form: --parameter value
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description='Extraction of WACCM model output for input to MusicBox.',
+        description='Extraction of WACCM or WRF-Chem model output for input to MusicBox.',
         formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument(
@@ -567,12 +567,13 @@ modelNames = [None, "waccm", "wrf-chem"]
 def main():
     # start with basic logging until args are parsed
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-    logger.info(f"{__file__}")
-    logger.info(f"Start time: {datetime.datetime.now()}")
 
     # retrieve and parse the command-line arguments
     myArgs = parse_arguments()
     setup_logging(myArgs.verbose)
+
+    logger.info(f"{__file__}")
+    logger.info(f"Start time: {datetime.datetime.now()}")
     logger.info(f"Command line = {myArgs}")
 
     # set up the directories

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -61,11 +61,6 @@ def parse_arguments():
         help='Directory containing WRF-Chem model output as NetCDF files.'
     )
     parser.add_argument(
-        '--musicaDir',
-        type=str,
-        help='Write MusicBox initial conditions into this directory as CSV and/or JSON.'
-    )
-    parser.add_argument(
         '--date',
         type=str,
         help="Date of model output to extract, in format YYYYMMDD"
@@ -120,10 +115,15 @@ def parse_arguments():
         version=f'MusicBox {__version__}',
     )
     parser.add_argument(
-        '--output',
+        '-o', '--output',
         type=str,
-        default="CSV",
-        help="Format(s) for writing the initial conditions: CSV,JSON"
+        action="append",
+        default=[],
+        help=("Path to save the initial/evolving conditions, including the file name."
+              + "\nIf not provided, result will be printed to the console."
+              + "\nUse the file extension to specify the output format: .csv or .json"
+              + "\nRepeat this argument to write output in multiple formats."
+        )
     )
     return parser.parse_args()
 
@@ -401,7 +401,12 @@ def isEnvironment(varName):
 # Write CSV file suitable for initial_conditions.csv in MusicBox.
 # initValues = dictionary of Musica varnames and (WACCM name, value, units)
 def writeInitCSV(initValues, filename):
-    fp = open(filename, "w")
+    console = False
+    if (filename == sys.stdout.name):
+        fp = sys.stdout
+        console = True
+    else:
+        fp = open(filename, "w")
 
     # write the column titles
     firstColumn = True
@@ -439,7 +444,8 @@ def writeInitCSV(initValues, filename):
             fp.write(f"{value[valueIndex][ri]}")
         fp.write("\n")
 
-    fp.close()
+    if not console:
+        fp.close()
     return
 
 
@@ -491,7 +497,6 @@ def writeInitJSON(initValues, filename):
     fpJson = open(filename, "w")
 
     json.dump(initConfig, fpJson, indent=2)
-    fpJson.close()
 
     fpJson.close()
     return
@@ -580,10 +585,6 @@ def main():
     waccmDir = myArgs.waccmDir
     wrfChemDir = myArgs.wrfchemDir
 
-    musicaDir = os.path.dirname(Examples.WACCM.path)
-    if (myArgs.musicaDir is not None):
-        musicaDir = myArgs.musicaDir
-
     template = Examples.TS1.path
     if (myArgs.template is not None):
         template = myArgs.template
@@ -650,16 +651,8 @@ def main():
 
     logger.info(f"lats = {lats}   lons = {lons}   alts = {alts}")
 
-    # get the requested (diagnostic) output
-    outputCSV = False
-    outputJSON = False
+    # write the requested (calculated) output
     insertIntoConfig = False
-    if (myArgs.output is not None):
-        # parameter is like: output=CSV,JSON
-        outputFormats = myArgs.output.split(",")
-        outputFormats = [lowFormat.lower() for lowFormat in outputFormats]
-        outputCSV = "csv" in outputFormats
-        outputJSON = "json" in outputFormats
 
     for modelDir, modelType, modelStride in zip(
             [waccmDir, wrfChemDir], [WACCM_OUT, WRFCHEM_OUT], [6, 1]):
@@ -755,24 +748,28 @@ def main():
         logger.info(f"Final frameCount = {frameCount}")
         logger.debug(f"Final WACCM accumValues = {accumValues}")
 
-        # Did we just calculate a single initial condition or multiple evolving?
-        spanConditions = "initial"
-        if (frameCount > 1):
-            spanConditions = "evolving"
+        # loop through the requested output files/formats
+        for output in myArgs.output:
+            logger.info(f"Writing output to {output} ...")
+            nameonly, extension = os.path.splitext(output)
+            extension = extension.replace('.', '').lower()
 
-        if (outputCSV):
-            # Write CSV file for MusicBox initial conditions.
-            csvName = os.path.join(musicaDir,
-                                   "{}_conditions-{}.csv".format(spanConditions, modelNames[modelType]))
-            logger.info(f"csvName = {csvName}")
-            writeInitCSV(accumValues, csvName)
+            if (extension in {"csv"}):
+                # Write CSV file for MusicBox initial conditions.
+                csvName = output
+                writeInitCSV(accumValues, csvName)
 
-        if (outputJSON):
-            # Write JSON file for MusicBox initial conditions.
-            jsonName = os.path.join(musicaDir,
-                                    "{}_config-{}.json".format(spanConditions, modelNames[modelType]))
-            logger.info(f"jsonName = {jsonName}")
-            writeInitJSON(accumValues, jsonName)
+            elif (extension in {"json"}):
+                # Write JSON file for MusicBox initial conditions.
+                jsonName = output
+                writeInitJSON(accumValues, jsonName)
+
+            else:
+                logger.warning(f"Skipping unrecognized file extension {output}")
+
+        if (len(myArgs.output) == 0):
+            # no output supplied; write CSV to console
+            writeInitCSV(accumValues, sys.stdout.name)
 
         if (insertIntoConfig):
             logger.info(f"Insert values into template {templateDir}")

--- a/python/tests/integration/configs/waccm_evolving_conditions/initial_concentrations.csv
+++ b/python/tests/integration/configs/waccm_evolving_conditions/initial_concentrations.csv
@@ -1,0 +1,2 @@
+time.s,ENV.temperature.K,ENV.pressure.Pa,CONC.O.mol m-3,CONC.O1D.mol m-3,CONC.O2.mol m-3,CONC.O3.mol m-3,CONC.N2.mol m-3
+0.0,217.6,1394.3,3.58e-11,1.83e-17,1.62e-1,6.43e-6,6.01e-1

--- a/python/tests/integration/configs/waccm_evolving_conditions/my_config.json
+++ b/python/tests/integration/configs/waccm_evolving_conditions/my_config.json
@@ -1,0 +1,249 @@
+{
+  "box model options": {
+    "grid": "box",
+    "chemistry time step [min]": 1.0,
+    "output time step [min]": 1.0,
+    "simulation length [day]": 3.0
+  },
+  "conditions": {
+    "filepaths": ["initial_concentrations.csv", "evolving_conditions.csv"]
+  },
+  "mechanism": {
+    "name": "Chapman",
+    "reactions": [
+        {
+            "type": "ARRHENIUS",
+            "A": 12947602.634,
+            "B": 0.0,
+            "C": 109.94829243348597,
+            "D": 300.0,
+            "E": 0.0,
+            "reactants": [
+                {
+                    "species name": "O1D",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "N2",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "N2",
+                    "coefficient": 1.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "ARRHENIUS",
+            "A": 19873064.508,
+            "B": 0.0,
+            "C": 54.97414621674299,
+            "D": 300.0,
+            "E": 0.0,
+            "reactants": [
+                {
+                    "species name": "O1D",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "ARRHENIUS",
+            "A": 4817712.608,
+            "B": 0.0,
+            "C": -2059.0316582998285,
+            "D": 300.0,
+            "E": 0.0,
+            "reactants": [
+                {
+                    "species name": "O",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O3",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O2",
+                    "coefficient": 2.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "ARRHENIUS",
+            "A": 217.59707599952029,
+            "B": -2.4,
+            "C": 0.0,
+            "D": 300.0,
+            "E": 0.0,
+            "reactants": [
+                {
+                    "species name": "O",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "M",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O3",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "M",
+                    "coefficient": 1.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "PHOTOLYSIS",
+            "name": "O2_1",
+            "scaling factor": 1.0,
+            "reactants": [
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O",
+                    "coefficient": 2.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "PHOTOLYSIS",
+            "name": "O3_1",
+            "scaling factor": 1.0,
+            "reactants": [
+                {
+                    "species name": "O3",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O1D",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                }
+            ],
+            "gas phase": "gas"
+        },
+        {
+            "type": "PHOTOLYSIS",
+            "name": "O3_2",
+            "scaling factor": 1.0,
+            "reactants": [
+                {
+                    "species name": "O3",
+                    "coefficient": 1.0
+                }
+            ],
+            "products": [
+                {
+                    "species name": "O",
+                    "coefficient": 1.0
+                },
+                {
+                    "species name": "O2",
+                    "coefficient": 1.0
+                }
+            ],
+            "gas phase": "gas"
+        }
+    ],
+    "species": [
+        {
+            "name": "M",
+            "is third body": true,
+            "__description": "Third-body molecule. This is any molecule present in the system."
+        },
+        {
+            "name": "O1D"
+        },
+        {
+            "name": "O"
+        },
+        {
+            "name": "O2"
+        },
+        {
+            "name": "O3"
+        },
+        {
+            "name": "N2"
+        },
+        {
+            "name": "Ar"
+        }
+    ],
+    "phases": [
+        {
+            "name": "gas",
+            "species": [
+                {
+                    "name": "M"
+                },
+                {
+                    "name": "O1D"
+                },
+                {
+                    "name": "O"
+                },
+                {
+                    "name": "O2"
+                },
+                {
+                    "name": "O3"
+                },
+                {
+                    "name": "N2"
+                },
+                {
+                    "name": "Ar"
+                }
+            ]
+        }
+    ],
+    "version": "1.0.0"
+
+  }
+}

--- a/python/tests/integration/test_waccm_conversion.py
+++ b/python/tests/integration/test_waccm_conversion.py
@@ -32,6 +32,10 @@ def test_waccm_to_music_box_conversion(temp_dir):
     repo_root = get_repo_root()
     sample_data_dir = os.path.join(repo_root, "sample_waccm_data")
 
+    # set up the output files
+    csvOutPath = os.path.join("waccmExtract", "initial_conditions-waccm.csv")
+    jsonOutPath = os.path.join("waccmExtract", "initial_conditions-waccm.json")
+
     # Set up arguments for the WACCM conversion
     args = [
         "--waccmDir", f"{sample_data_dir}",
@@ -39,15 +43,21 @@ def test_waccm_to_music_box_conversion(temp_dir):
         "--time", "12:00",
         "--latitude", "3.1",
         "--longitude", "101.7",
-        "--output", "csv,json"
+        "--output", csvOutPath,
+        "-o", jsonOutPath,
+        "--verbose"
     ]
 
     # Run the waccmToMusicBox script with the arguments
     run_waccm_to_music_box_with_args(args, temp_dir)
 
     # Check if the output files are created
-    assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_conditions-waccm.csv"))
-    assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_config-waccm.json"))
+    assert os.path.exists(os.path.join(temp_dir, csvOutPath))
+    assert os.path.exists(os.path.join(temp_dir, jsonOutPath))
+
+    # set up the output files
+    csvOutPath = os.path.join("wrfchemExtract", "initial_conditions-wrfchem.csv")
+    jsonOutPath = os.path.join("wrfchemExtract", "initial_conditions-wrfchem.json")
 
     # Set up arguments for the WRF-Chem conversion
     args = [
@@ -56,7 +66,8 @@ def test_waccm_to_music_box_conversion(temp_dir):
         "--time", "08:00",
         "--latitude", "47.0,49.0",
         "--longitude", "'-123.0,-121.0'",
-        "--output", "csv,json"
+        "--output", csvOutPath,
+        "-o", jsonOutPath
     ]
 
     # Create symbolic link from Linux colon filename pointing to Window-safe hyphen file.
@@ -76,5 +87,5 @@ def test_waccm_to_music_box_conversion(temp_dir):
     run_waccm_to_music_box_with_args(args, temp_dir)
 
     # Check if the output files are created
-    assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_conditions-wrf-chem.csv"))
-    assert os.path.exists(os.path.join(os.path.dirname(Examples.WACCM.path), "initial_config-wrf-chem.json"))
+    assert os.path.exists(os.path.join(temp_dir, csvOutPath))
+    assert os.path.exists(os.path.join(temp_dir, jsonOutPath))

--- a/python/tests/integration/test_waccm_evolving_conditions.py
+++ b/python/tests/integration/test_waccm_evolving_conditions.py
@@ -40,7 +40,7 @@ def run_command_with_args(cmdName, args, cwd):
 
 
 def test_waccm_evolving_conditions(temp_dir):
-    print(f"temp_dir1 = {temp_dir}")
+    print(f"temp_dir = {temp_dir}")
 
     # Step 1: Create a required CSV by converting WACCM data.
     repo_root = get_repo_root()
@@ -70,7 +70,7 @@ def test_waccm_evolving_conditions(temp_dir):
 
     # Run the waccmToMusicBox script with the arguments
     run_command_with_args("waccmToMusicBox", args, temp_dir)
-    assert os.path.exists(os.path.join(temp_dir, csvOutPath))
+    assert os.path.exists(csvOutPath)
 
     # Step 2: Now run MusicBox with that CSV file containing WACCM data.
     # This portion of the test will fail if waccmToMusicBox did not run correctly.
@@ -78,7 +78,7 @@ def test_waccm_evolving_conditions(temp_dir):
     # capture the output file
     configPath = os.path.join(repo_root, "python", "tests", "integration",
         "configs", "waccm_evolving_conditions", "my_config.json")
-    outputPath = os.path.join(repo_root, "python", "tests", "integration",
+    outputPath = os.path.join(temp_dir,
         "configs", "waccm_evolving_conditions", "evolving_output.csv")
 
     # make sure to create entirely new test file
@@ -94,5 +94,5 @@ def test_waccm_evolving_conditions(temp_dir):
     # Run the waccmToMusicBox script with the arguments
     run_command_with_args("music_box", args, temp_dir)
     print(f"outputPath = {outputPath}")
-    assert os.path.exists(os.path.join(temp_dir, outputPath))
+    assert os.path.exists(outputPath)
 

--- a/python/tests/integration/test_waccm_evolving_conditions.py
+++ b/python/tests/integration/test_waccm_evolving_conditions.py
@@ -1,59 +1,91 @@
 from acom_music_box import MusicBox
 
 import os
+import pytest
+import tempfile
+import sys
+from acom_music_box.main import main as musicBoxMain
+from acom_music_box.tools.waccmToMusicBox import main as waccmToMusicBoxMain
 import pandas as pd
 import math
 
 
-class TestWaccmEvolvingConditions:
-    def test_run(self):
-
-        # Create a required CSV by converting WACCM data.
-        repo_root = get_repo_root()
-        sample_data_dir = os.path.join(repo_root, "sample_waccm_data")
-
-        # set up the output files
-        csvOutPath = os.path.join(repo_root, "python", "tests", "integration",
-            "configs", "waccm_evolving_conditions", "evolving_conditions.csv")
-
-        # Set up arguments for the WACCM conversion
-        args = [
-            "--waccmDir", f"{sample_data_dir}",
-            "--date", "20260208,20260208",
-            "--time", "00:00,23:00",
-            "--latitude", "2.7,13.8",
-            "--longitude", "101.7,123.8",
-            "--altitude", "567.8,4567.8",
-            "--output", csvOutPath,
-            "--verbose"
-        ]
-
-        # Run the waccmToMusicBox script with the arguments
-        run_waccm_to_music_box_with_args(args, temp_dir)
-
-        # Now run MusicBox with that CSV file containing WACCM data.
-        # This portion of the test will fail if waccmToMusicBox did not run correctly.
-        music_box = MusicBox()
-
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        config_path = os.path.join(current_dir, "configs", "waccm_evolving_conditions", "my_config.json")
-        music_box.loadJson(config_path)
-
-        results = music_box.solve()
-        assert results is not None
-
-        # Get values from DataFrame columns
-        temperatures = results["ENV.temperature.K"]
-        pressures = results["ENV.pressure.Pa"]
-        assert len(temperatures) == len(pressures)
-
-        for temp, press in zip(temperatures, pressures):
-            assert temp is not None
-            assert press is not None
-            assert math.isclose(temp, 287.0, rel_tol=0.004)
-            assert math.isclose(press, 78750.0, rel_tol=0.002)
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield tmpdirname
 
 
-if __name__ == "__main__":
-    test = TestWaccmEvolvingConditions()
-    test.test_run()
+def get_repo_root():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+
+
+# cmdName = "waccmToMusicBox" or "music_box"
+# args = command-line parameters
+# cmd = temporary directory for running this test
+def run_command_with_args(cmdName, args, cwd):
+    original_argv = sys.argv
+    original_cwd = os.getcwd()
+    sys.argv = [cmdName] + args
+    try:
+        os.chdir(cwd)
+        if (cmdName == "waccmToMusicBox"):
+            waccmToMusicBoxMain()
+        if (cmdName == "music_box"):
+            musicBoxMain()
+    finally:
+        os.chdir(original_cwd)
+        sys.argv = original_argv
+
+
+def test_waccm_evolving_conditions(temp_dir):
+    print(f"temp_dir1 = {temp_dir}")
+
+    # Step 1: Create a required CSV by converting WACCM data.
+    repo_root = get_repo_root()
+    sample_data_dir = os.path.join(repo_root, "sample_waccm_data")
+
+    # set up the output files
+    configPath = os.path.join(repo_root, "python", "tests", "integration",
+        "configs", "waccm_evolving_conditions")
+    csvOutPath = os.path.join(repo_root, "python", "tests", "integration",
+        "configs", "waccm_evolving_conditions", "evolving_conditions.csv")
+
+    # Set up arguments for the WACCM conversion
+    args = [
+        "--waccmDir", f"{sample_data_dir}",
+        "--date", "20260208,20260208",
+        "--time", "00:00,23:00",
+        "--latitude", "2.7,13.8",
+        "--longitude", "101.7,123.8",
+        "--altitude", "567.8,4567.8",
+        "--template", configPath,
+        "--output", csvOutPath,
+        "--verbose"
+    ]
+
+    # Run the waccmToMusicBox script with the arguments
+    run_command_with_args("waccmToMusicBox", args, temp_dir)
+    assert os.path.exists(os.path.join(temp_dir, csvOutPath))
+
+    # Step 2: Now run MusicBox with that CSV file containing WACCM data.
+    # This portion of the test will fail if waccmToMusicBox did not run correctly.
+
+    # capture the output file
+    configPath = os.path.join(repo_root, "python", "tests", "integration",
+        "configs", "waccm_evolving_conditions", "my_config.json")
+    outputPath = os.path.join(repo_root, "python", "tests", "integration",
+        "configs", "waccm_evolving_conditions", "evolving_output.csv")
+
+    # Set up arguments for the WACCM conversion
+    args = [
+        "--config", configPath,
+        "--output", outputPath,
+        "--verbose", "-v"
+    ]
+
+    # Run the waccmToMusicBox script with the arguments
+    run_command_with_args("music_box", args, temp_dir)
+    print(f"outputPath = {outputPath}")
+    assert os.path.exists(os.path.join(temp_dir, outputPath))
+

--- a/python/tests/integration/test_waccm_evolving_conditions.py
+++ b/python/tests/integration/test_waccm_evolving_conditions.py
@@ -1,0 +1,59 @@
+from acom_music_box import MusicBox
+
+import os
+import pandas as pd
+import math
+
+
+class TestWaccmEvolvingConditions:
+    def test_run(self):
+
+        # Create a required CSV by converting WACCM data.
+        repo_root = get_repo_root()
+        sample_data_dir = os.path.join(repo_root, "sample_waccm_data")
+
+        # set up the output files
+        csvOutPath = os.path.join(repo_root, "python", "tests", "integration",
+            "configs", "waccm_evolving_conditions", "evolving_conditions.csv")
+
+        # Set up arguments for the WACCM conversion
+        args = [
+            "--waccmDir", f"{sample_data_dir}",
+            "--date", "20260208,20260208",
+            "--time", "00:00,23:00",
+            "--latitude", "2.7,13.8",
+            "--longitude", "101.7,123.8",
+            "--altitude", "567.8,4567.8",
+            "--output", csvOutPath,
+            "--verbose"
+        ]
+
+        # Run the waccmToMusicBox script with the arguments
+        run_waccm_to_music_box_with_args(args, temp_dir)
+
+        # Now run MusicBox with that CSV file containing WACCM data.
+        # This portion of the test will fail if waccmToMusicBox did not run correctly.
+        music_box = MusicBox()
+
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        config_path = os.path.join(current_dir, "configs", "waccm_evolving_conditions", "my_config.json")
+        music_box.loadJson(config_path)
+
+        results = music_box.solve()
+        assert results is not None
+
+        # Get values from DataFrame columns
+        temperatures = results["ENV.temperature.K"]
+        pressures = results["ENV.pressure.Pa"]
+        assert len(temperatures) == len(pressures)
+
+        for temp, press in zip(temperatures, pressures):
+            assert temp is not None
+            assert press is not None
+            assert math.isclose(temp, 287.0, rel_tol=0.004)
+            assert math.isclose(press, 78750.0, rel_tol=0.002)
+
+
+if __name__ == "__main__":
+    test = TestWaccmEvolvingConditions()
+    test.test_run()

--- a/python/tests/integration/test_waccm_evolving_conditions.py
+++ b/python/tests/integration/test_waccm_evolving_conditions.py
@@ -8,6 +8,7 @@ from acom_music_box.main import main as musicBoxMain
 from acom_music_box.tools.waccmToMusicBox import main as waccmToMusicBoxMain
 import pandas as pd
 import math
+import pathlib
 
 
 @pytest.fixture
@@ -51,6 +52,9 @@ def test_waccm_evolving_conditions(temp_dir):
     csvOutPath = os.path.join(repo_root, "python", "tests", "integration",
         "configs", "waccm_evolving_conditions", "evolving_conditions.csv")
 
+    # make sure to create entirely new test file
+    pathlib.Path(csvOutPath).unlink(missing_ok=True)
+
     # Set up arguments for the WACCM conversion
     args = [
         "--waccmDir", f"{sample_data_dir}",
@@ -76,6 +80,9 @@ def test_waccm_evolving_conditions(temp_dir):
         "configs", "waccm_evolving_conditions", "my_config.json")
     outputPath = os.path.join(repo_root, "python", "tests", "integration",
         "configs", "waccm_evolving_conditions", "evolving_output.csv")
+
+    # make sure to create entirely new test file
+    pathlib.Path(outputPath).unlink(missing_ok=True)
 
     # Set up arguments for the WACCM conversion
     args = [


### PR DESCRIPTION
Corrected the instructions for WACCM and WRF-Chem import of initial and evolving conditions to MusicBox. Use --output for specifying where the output is written. Added integration test that runs waccmToMusicBox to create evolving_conditions.CSV, then runs music_box to verify that the conditions.CSV file is acceptable.

This Pull Request closes issue #454: https://github.com/NCAR/music-box/issues/454