### PR TITLE
463 waccmToMusicBox - look through all netcdf files for initial and evolving conditions

### DIFF
--- a/.github/workflows/CI_Tests.yml
+++ b/.github/workflows/CI_Tests.yml
@@ -61,6 +61,6 @@ jobs:
         music_box -e Analytical -o output.csv
         music_box -e Analytical -o output.csv -vv --color-output
         waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20240904" --time "07:00" --latitude 3.1 --longitude 101.7
-        waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
+        waccmToMusicBox --wrfchemDir "./sample_waccm_data/20250820/wrf" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 
       shell: pwsh

--- a/python/README.md
+++ b/python/README.md
@@ -167,7 +167,7 @@ waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00
 ```
 
 ```bash
-waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
+waccmToMusicBox --wrfchemDir "./sample_waccm_data/20250820/wrf" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```
 
 waccmToMusicBox uses a MUSICA configuration file to create a list of common chemical species between MusicBox and WACCM or WRF-Chem.

--- a/python/README.md
+++ b/python/README.md
@@ -158,7 +158,7 @@ waccmToMusicBox --help
 
 You may specify a single point in space and date-time by passing single values to date, time, latitude, and longitude.
 Altitude defaults to the surface.
-You may also specify a rectangle or cube by specifying multiple values for latitude, longitude, and altitude.
+You may also specify a rectangle or a cube by specifying multiple values for latitude, longitude, and altitude.
 Use a lat-lon variable (PBLH) to bound the vertical dimension at a specific height.
 If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
 
@@ -170,7 +170,7 @@ waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00
 waccmToMusicBox --wrfchemDir "./sample_waccm_data" --date "20250820" --time "08:00" --latitude 47.0,49.0 --longitude "'-123.0,-121.0'"
 ```
 
-waccmToMusicBox uses MUSICA configuration file to create a list of common chemical species between MusicBox and WACCM or WRF-Chem.
+waccmToMusicBox uses a MUSICA configuration file to create a list of common chemical species between MusicBox and WACCM or WRF-Chem.
 The default configuration file is in the ts1 example because that example has many species.
 Use the --template parameter to specify your own configuration file (usually my_config.json).
 

--- a/python/README.md
+++ b/python/README.md
@@ -150,7 +150,7 @@ music_box -e TS1 --plot O3 --plot-output-unit ppb
 ## Tool: waccmToMusicBox
 
 This tool allows you to extract chemical species concentrations from WACCM or WRF-Chem model output and write them as MusicBox initial conditions.
-Use the built-in help to display all options including template configurations and multiple output formats:
+Use the built-in help to display all options including template configurations and output files:
 
 ```bash
 waccmToMusicBox --help
@@ -158,9 +158,9 @@ waccmToMusicBox --help
 
 You may specify a single point in space and date-time by passing single values to date, time, latitude, and longitude.
 Altitude defaults to the surface.
-You may also specify a rectangle or a cube by specifying multiple values for latitude, longitude, and altitude.
+You may also specify a rectangle or a cube by specifying pairs of values for latitude, longitude, and altitude.
 Use a lat-lon variable (PBLH) to bound the vertical dimension at a specific height.
-If you request two date-time pairs, the tool will create evolving conditions over time rather than initial conditions.
+If you request a pair of dates and a pair of times, the tool will create evolving conditions over time rather than initial conditions.
 
 ```bash
 waccmToMusicBox --waccmDir "./sample_waccm_data" --date "20260208" --time "07:00" --latitude 3.1 --longitude 101.7 --verbose
@@ -181,6 +181,17 @@ waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output --date 20250820,20
 ```bash
 waccmToMusicBox --waccmDir ~/MusicBox/WACCM/model-output --date 20240301,20240304 --time 17:00,04:00 --latitude "'-4.0,-2.0'" --longitude 101.0,103.0 --altitude 567.8,4567.8 --template ./examples/ts1 --output conditions/evolving_conditions.csv --verbose -v
 ```
+
+When you specify waccmDir and wrfchemDir, waccmToMusicBox will scan all the NetCDF files in that directory to determine the date-time steps that they contain.
+Then when you specify a date-time for the extraction, waccmToMusicBox will look for the time step within 5 minutes of the requested date-time.
+If you specify a pair of date-times for evolving conditions, waccmToMusicBox will use your date window and hour stride to locate the proper time steps.
+You may specify several directories to scan; for example, WRF-Chem forecast output is often saved into daily directories:
+
+```bash
+waccmToMusicBox --wrfchemDir ~/MusicBox/WRF-Chem/model-output/20250820/wrf --wrfchemDir ~/MusicBox/WRF-Chem/model-output/20250821/wrf --date 20250820,20250822 --time 18:00,05:00 --latitude 47.0,49.0 --longitude "'-123.0,-121.0'" --template ../../../examples/ts1 --output musicbox-out/evolving_conditions-wrfchem.csv --verbose
+```
+
+waccmToMusicBox will also follow links to NetCDF files, in case you need to avoid copying multi-GB files around.
 
 ## Development
 

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -39,7 +39,7 @@ class Model_File:
 
 # WACCM output file
 class WACCM_File(Model_File):
-    def __init__(self, myPath = "blank.txt"):
+    def __init__(self, myPath = "blank-WACCM.txt"):
         super().__init__(myPath)
         logger.debug(f"WACCM file type: {myPath}")
 
@@ -56,6 +56,10 @@ class WACCM_File(Model_File):
 
 
 class WRF_Chem_File(Model_File):
+    def __init__(self, myPath = "blank-WRF-Chem.txt"):
+        super().__init__(myPath)
+        logger.debug(f"WRF-Chem file type: {myPath}")
+
     # WRF-Chem:   Times = "2025-08-20_08:00:00";                  char
     def inventoryDateTimes(self, fileDataset):
         super().inventoryDateTimes(fileDataset)
@@ -111,4 +115,28 @@ def collectFilesDates(modelDir, modelClass):
 # Sort list of model files in place, by first date-time contained.
 def sortFiles(myModelList):
    myModelList.sort(key=lambda modelFile: modelFile.dateTimes[0])
+
+
+# Expand the original Model_File collection:
+#    File2:  time1, time2, time3, time4
+# strictly into pairs:
+#    File2:  time1
+#    File2:  time2
+#    File2:  time3
+#    File2:  time4
+# This separation makes the extraction loop easier
+# and permits interleaving of model output frames.
+# Return the separated pairs as Model_Files objects.
+def collectionToPairs(myFiles):
+    pairCollection = []
+
+    for compositeFile in myFiles:
+        for myTime in compositeFile.dateTimes:
+            pairFile = Model_File(compositeFile.filePath)
+            pairFile.dateTimes = [myTime]
+            pairCollection.append(pairFile)
+
+    # sort the file objects by date-time
+    sortFiles(pairCollection)
+    return pairCollection
 

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -140,3 +140,19 @@ def collectionToPairs(myFiles):
     sortFiles(pairCollection)
     return pairCollection
 
+
+dateTimeTolerance = datetime.timedelta(minutes = 5)
+
+# Locate and return the closest model file to the requested date-time.
+# "Nearest" currently is the first file within the tolerance above.
+# myDateTime = seeking this model step
+# myModelFiles = list of Model_File objects, sorted by date-time
+def findNearestDateTime(myDateTime, myModelFiles):
+
+    for modelFile in myModelFiles:
+        timeDifference = abs(myDateTime - modelFile.dateTimes[0])
+        if (timeDifference < dateTimeTolerance):
+            return modelFile.filePath
+
+    return None
+

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -78,6 +78,10 @@ class WRF_Chem_File(Model_File):
 # Scan a directory and create a list of NetCDF files.
 # Each file represents several time steps of model output.
 # Those times are collected with the filename.
+# Note: The NetCDF files currently produced by the ACOM near-real-time
+# forecast system do not have any extension:
+#     wrfout_hourly_d02_2025-08-21_08:00:00
+# That is why we don't glob() on *.nc as of May 18, 2026.
 # We can tolerate README.txt files in the same directory.
 # modelDir = scan this directory
 # modelClass = class of model (WACCM or WRF-Chem) expected in this directory

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -6,16 +6,109 @@
 # Copyright 2026 by Atmospheric Chemistry Observations & Modeling (UCAR/ACOM)
 
 import sys
-import math
-import numbers
-import numpy
+#import math
+#import numbers
+#import numpy
+import pathlib
 import xarray
-import netCDF4
+import datetime
+#import netCDF4
 
 import logging
 logger = logging.getLogger(__name__)
 
 
-def collectFilesDates(modelDir):
-    return []
+# A file (probably NetCDF) containing output from an atmospheric model.
+class Model_File:
+    def __init__(self, myPath):
+        self.filePath = myPath       # full directory, name, and file extension
+        self.dateTimes = []          # date-time steps contained in the file
+
+    # show the fields of this object
+    def display(self):
+        friendlyDates = [f"{dt}" for dt in self.dateTimes]
+        logger.info(f"\t{self.filePath}:\n\t\t{friendlyDates}")
+
+    # gather the date-time values contained in this file
+    # The file is open and known to be NetCDF file.
+    # fileDataSet = xarray dataset
+    # dateTimes[] should be loaded
+    def inventoryDateTimes(self, fileDataset):
+        logger.debug(f"inventoryDateTimes for {self}")
+
+
+# WACCM output file
+class WACCM_File(Model_File):
+    def __init__(self, myPath = "blank.txt"):
+        super().__init__(myPath)
+        logger.debug(f"WACCM file type: {myPath}")
+
+    # WACCM: date = 20260208, 20260208, 20260208, 20260208 ; int
+    #        datesec = 0, 21600, 43200, 64800 ;              int
+    def inventoryDateTimes(self, fileDataset):
+        super().inventoryDateTimes(fileDataset)
+        for date, datesec in zip(fileDataset["date"].data, fileDataset["datesec"].data):
+            logger.debug(f"date = {date}   datesec = {datesec}")
+            dateStr = str(date)
+            stepDate = (datetime.datetime.strptime(dateStr, "%Y%m%d")
+                + datetime.timedelta(seconds=int(datesec)))
+            self.dateTimes.append(stepDate)
+
+
+class WRF_Chem_File(Model_File):
+    # WRF-Chem:   Times = "2025-08-20_08:00:00";                  char
+    def inventoryDateTimes(self, fileDataset):
+        super().inventoryDateTimes(fileDataset)
+        timesVar = fileDataset["Times"].data
+        timesVarStrings = [tv.decode("utf-8") for tv in timesVar]
+        for timeStr in timesVarStrings:
+            logger.debug(f"timeStr = {timeStr}")
+            stepDate = datetime.datetime.strptime(timeStr, "%Y-%m-%d_%H:%M:%S")
+            self.dateTimes.append(stepDate)
+
+
+# Scan a directory and create a list of NetCDF files.
+# Each file represents several time steps of model output.
+# Those times are collected with the filename.
+# We can tolerate README.txt files in the same directory.
+# modelDir = scan this directory
+# modelClass = class of model (WACCM or WRF-Chem) expected in this directory
+# return list of populated modelClass objects
+def collectFilesDates(modelDir, modelClass):
+    # retrieve filenames
+    dirFiles = [f for f in pathlib.Path(modelDir).iterdir() if f.is_file()]
+    logger.debug(f"dirFiles = {dirFiles}")
+
+    # create Model_File objects for each filename
+    # This first list might not be all NetCDF files.
+    maybeFiles = []
+    for dirFile in dirFiles:
+        myModelFile = modelClass(dirFile)
+        maybeFiles.append(myModelFile)
+
+    # extract the date and time
+    # This second list of files are known to be NetCDF.
+    modelFiles = []
+    for maybeFile in maybeFiles:
+        try:
+            # attempt to open the file as NetCDF
+            filename = maybeFile.filePath
+            with xarray.open_dataset(filename) as dataSet:
+                logger.debug(f"Opened {filename}")
+            modelFiles.append(maybeFile)
+
+            # gather all the date-times in the file
+            maybeFile.inventoryDateTimes(dataSet)
+
+        except ValueError as oops:
+            logger.warning(f"Cannot open {filename} because it is not a NetCDF file.")
+            logger.debug(f"Cannot open {filename} because {oops}.")
+
+    # pass back just the NetCDF files
+    return modelFiles
+
+
+# Sort list of model files in place, by first date-time contained.
+def sortFiles(myModelList):
+   myModelList.sort(key=lambda modelFile: modelFile.dateTimes[0])
 

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -6,13 +6,9 @@
 # Copyright 2026 by Atmospheric Chemistry Observations & Modeling (UCAR/ACOM)
 
 import sys
-#import math
-#import numbers
-#import numpy
 import pathlib
 import xarray
 import datetime
-#import netCDF4
 
 import logging
 logger = logging.getLogger(__name__)

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 # A file (probably NetCDF) containing output from an atmospheric model.
 class Model_File:
+    hourStride = 1                   # default time step for model output
+
     def __init__(self, myPath):
         self.filePath = myPath       # full directory, name, and file extension
         self.dateTimes = []          # date-time steps contained in the file
@@ -39,6 +41,8 @@ class Model_File:
 
 # WACCM output file
 class WACCM_File(Model_File):
+    hourStride = 6       # WACCM global output is typically every 6 hours
+
     def __init__(self, myPath = "blank-WACCM.txt"):
         super().__init__(myPath)
         logger.debug(f"WACCM file type: {myPath}")

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # A file (probably NetCDF) containing output from an atmospheric model.
 class Model_File:
     hourStride = 1                   # default time step for model output
+    modelType = "Generic model"      # for diagnosing errors of wrong model type
 
     def __init__(self, myPath):
         self.filePath = myPath       # full directory, name, and file extension
@@ -42,6 +43,7 @@ class Model_File:
 # WACCM output file
 class WACCM_File(Model_File):
     hourStride = 6       # WACCM global output is typically every 6 hours
+    modelType = "WACCM"
 
     def __init__(self, myPath = "blank-WACCM.txt"):
         super().__init__(myPath)
@@ -60,6 +62,8 @@ class WACCM_File(Model_File):
 
 
 class WRF_Chem_File(Model_File):
+    modelType = "WRF-Chem"
+
     def __init__(self, myPath = "blank-WRF-Chem.txt"):
         super().__init__(myPath)
         logger.debug(f"WRF-Chem file type: {myPath}")
@@ -111,6 +115,11 @@ def collectFilesDates(modelDir, modelClass):
         except ValueError as oops:
             logger.warning(f"Cannot open {filename} because it is not a NetCDF file.")
             logger.debug(f"Cannot open {filename} because {oops}.")
+
+        except KeyError as oops:
+            logger.warning(f"Cannot find expected date-time in {filename} as {modelClass.modelType} model output."
+                + " Wrong model specified?")
+            logger.debug(f"Cannot get date-time for {filename} because {oops}.")
 
     # pass back just the NetCDF files
     return modelFiles

--- a/python/acom_music_box/tools/fileUtils.py
+++ b/python/acom_music_box/tools/fileUtils.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# fileUtils.py
+# MusicBox: Utility functions for managing collections of NetCDF files.
+#
+# Author: Carl Drews
+# Copyright 2026 by Atmospheric Chemistry Observations & Modeling (UCAR/ACOM)
+
+import sys
+import math
+import numbers
+import numpy
+import xarray
+import netCDF4
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def collectFilesDates(modelDir):
+    return []
+

--- a/python/acom_music_box/tools/gridUtils.py
+++ b/python/acom_music_box/tools/gridUtils.py
@@ -425,7 +425,7 @@ def meanCurvedGrid(gridDataset, when, latPair, lonPair, altPair,
     timesVar = gridDataset["Times"]
     timesVarStrings = timesVar.str.decode("utf-8")
     stringMatches = numpy.where(timesVarStrings == whenStr)
-    timeIndex = stringMatches[0][0]
+    timeIndex = stringMatches[0][0]             # [tuple][first match]
     logger.info(f"timeIndex = {timeIndex}")
 
     # estimate the grid spacing
@@ -460,7 +460,6 @@ def meanCurvedGrid(gridDataset, when, latPair, lonPair, altPair,
 
     iLat, iLon = None, None
     singlePoints = []
-    timeIndex = 0
     for latFloat in latTicks:
         logger.info(f"latFloat = {latFloat}")
         for lonFloat in lonTicks:

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -263,9 +263,7 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
         varMap = {
             # WRF-Chem: MusicBox
             "T2": "temperature",
-            "PB": "pressure",
-            "isopr": "ISOPB02",
-            "o3": "O3"
+            "PB": "pressure"
         }
 
     for varName in inCommon:

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -677,9 +677,14 @@ def main():
             outFiles = fileUtils.collectFilesDates(modelDir, modelType)
             allFiles.extend(outFiles)
 
+        logger.info(f"Collected files with multiple times:")
+        for outFile in allFiles:
+            outFile.display()
+
+        # separate the collection of file:times into pairs of file:time
         # sort the output files by date-time
-        fileUtils.sortFiles(allFiles)
-        logger.info(f"Collected files (sorted):")
+        allFiles = fileUtils.collectionToPairs(allFiles)
+        logger.info(f"Collected and sorted file-time pairs:")
         for outFile in allFiles:
             outFile.display()
 

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -659,10 +659,10 @@ def main():
     insertIntoConfig = False
 
     # process the two model types
-    for modelDirs, modelType, modelStride in zip(
+    for modelDirs, modelType in zip(
             [waccmDir, wrfChemDir],
             [fileUtils.WACCM_File, fileUtils.WRF_Chem_File],
-            [6, 1]):
+            ):
         if (len(modelDirs) == 0):
             continue
 
@@ -686,7 +686,7 @@ def main():
             outFile.display()
 
         # possibly exit here if just collecting files
-        #sys.exit(0)    # bogus
+        #sys.exit(0)
 
         # determine the date-time bounds to retrieve
         startDateTime = datetime.datetime.strptime(
@@ -699,7 +699,7 @@ def main():
         logger.info(f"Calculate averages from date-time {startDateTime} to {endDateTime}.")
 
         # determine the interval for time frames
-        strideHours = modelStride
+        strideHours = modelType.hourStride
         if (strideArg is not None):
             strideHours = strideArg
         logger.info(f"stride = {strideHours} hours")

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -21,6 +21,7 @@ from acom_music_box import Examples, __version__
 from acom_music_box.utils import calculate_air_density
 import netCDF4
 from acom_music_box.tools import gridUtils
+from acom_music_box.tools import fileUtils
 from acom_music_box import conditions_manager
 import copy
 
@@ -53,11 +54,15 @@ def parse_arguments():
     parser.add_argument(
         '--waccmDir',
         type=str,
+        action="append",
+        default=[],
         help='Directory containing WACCM model output as NetCDF files.'
     )
     parser.add_argument(
         '--wrfchemDir',
         type=str,
+        action="append",
+        default=[],
         help='Directory containing WRF-Chem model output as NetCDF files.'
     )
     parser.add_argument(
@@ -250,6 +255,7 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
     # the common species between WACCM and MUSICA.
     if (modelType == WACCM_OUT):
         varMap = {
+            # WACCM: MusicBox
             "T": "temperature",
             "lev": "pressure"       # sigma pressure coordinates
         }
@@ -666,10 +672,12 @@ def main():
 
     for modelDir, modelType, modelStride in zip(
             [waccmDir, wrfChemDir], [WACCM_OUT, WRFCHEM_OUT], [6, 1]):
-        if not modelDir:
+        if (len(modelDir) == 0):
             continue
 
-        logger.info(f"Directory: {modelDir}   type {modelType}")
+        logger.info(f"Directories: {modelDir}   type {modelType}")
+        files = fileUtils.collectFilesDates(modelDir)
+        logger.info(f"Collected files: {files}")
 
         # determine the date-time bounds to retrieve
         startDateTime = datetime.datetime.strptime(
@@ -710,14 +718,14 @@ def main():
                 waccmFilename = os.path.join(dateDir, "wrf", waccmFilename)
 
             # if this frame time is not present, skip
-            waccmFullPath = os.path.join(modelDir, waccmFilename)
+            waccmFullPath = os.path.join(modelDir[0], waccmFilename)
             if not os.path.exists(waccmFullPath):
                 logger.warning(f"File {waccmFullPath} does not exist. Skipping...")
                 when += datetime.timedelta(hours=strideHours)
                 continue
 
             # read and glean chemical species from WACCM and MUSICA
-            waccmChems = getWaccmSpecies(modelDir, waccmFilename)
+            waccmChems = getWaccmSpecies(modelDir[0], waccmFilename)
             musicaChems = getMusicaSpecies(templateFile)
 
             # create map of species common to both WACCM and MUSICA
@@ -733,7 +741,7 @@ def main():
             # Read named variables from WACCM model output.
             logger.info(f"Retrieve WACCM conditions at ({lats} North, {lons} East)   when {when}.")
             waccmValues = readWACCM(commonDict, lats, lons, alts,
-                                    when, modelDir, waccmFilename, modelType)
+                                    when, modelDir[0], waccmFilename, modelType)
             logger.debug(f"Original WACCM waccmValues = {waccmValues}")
             varValues.update(waccmValues)
 

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -170,16 +170,14 @@ def isFloat(numString):
 
 # Create and return list of WACCM chemical species
 # that will be mapped to MUSICA.
-# modelDir = directory containing model output
-# waccmFilename = name of WACCM model output file
+# waccmFilename = full path to WACCM model output
 # return list of variable names
-def getWaccmSpecies(modelDir, waccmFilename):
+def getWaccmSpecies(waccmFilename):
     # create the filename
     logger.info(f"WACCM species file = {waccmFilename}")
 
     # open dataset for reading
-    waccmDataSet = xarray.open_dataset(os.path.join(modelDir, waccmFilename),
-                                       engine="netcdf4")
+    waccmDataSet = xarray.open_dataset(waccmFilename, engine="netcdf4")
 
     # collect the data variables
     waccmNames = [varName for varName in waccmDataSet.data_vars]
@@ -259,7 +257,7 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
             "T": "temperature",
             "lev": "pressure"       # sigma pressure coordinates
         }
-    elif (modelType == fileUtils.WRF_Chem_file):
+    elif (modelType == fileUtils.WRF_Chem_File):
         varMap = {
             # WRF-Chem: MusicBox
             "T2": "temperature",
@@ -278,14 +276,12 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
 #   Could be a single point or corners of a selection rectangle.
 # altitudes = height bounds across which to average (meters)
 # when = date and time to extract
-# modelDir = directory containing model output
-# waccmFilename = name of the model output file
+# waccmFilepath = full path to model output file
 # modelType = WACCM_File or WRF)Chem_File
 # return dictionary of MUSICA variable names, units, and values
 def readWACCM(waccmMusicaDict, latitudes, longitudes, altitudes,
-              when, modelDir, waccmFilename, modelType):
+              when, waccmFilepath, modelType):
 
-    waccmFilepath = os.path.join(modelDir, waccmFilename)
     logger.info(f"WACCM file path = {waccmFilepath}")
 
     # open dataset for reading
@@ -677,6 +673,7 @@ def main():
             outFiles = fileUtils.collectFilesDates(modelDir, modelType)
             allFiles.extend(outFiles)
 
+        # the filenames include the full directory path
         logger.info(f"Collected files with multiple times:")
         for outFile in allFiles:
             outFile.display()
@@ -714,30 +711,17 @@ def main():
             logger.info(f"Extracting date-time {when}:")
             seconds = (when - startDateTime).total_seconds()
 
-            # locate the WACCM output file
-            if (modelType == fileUtils.WACCM_File):
-                waccmFilename = f"f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{when.year:4d}-{when.month:02d}-{when.day:02d}-00000.nc"
-            elif (modelType == fileUtils.WRF_Chem_File):
-                waccmFilename = f"wrfout_hourly_d01_{when.year:4d}-{when.month:02d}-{when.day:02d}_{when.hour:02d}:00:00"
-
-            # Windows does not allow colons : in filenames. Replace with hyphen -.
-            if not pathvalidate.is_valid_filename(waccmFilename, platform="auto"):
-                waccmFilename = waccmFilename.replace(":", "-")
-
-            if (modelType == fileUtils.WRF_Chem_File):
-                # WRF-Chem convention stores files in sub-directories by date
-                dateDir = f"{when.year:4d}{when.month:02d}{when.day:02d}"
-                waccmFilename = os.path.join(dateDir, "wrf", waccmFilename)
+            # locate the WACCM / WRF-Chem output filepath for this date-time
+            waccmFilename = fileUtils.findNearestDateTime(when, allFiles)
 
             # if this frame time is not present, skip
-            waccmFullPath = os.path.join(modelDirs[0], waccmFilename)
-            if not os.path.exists(waccmFullPath):
-                logger.warning(f"File {waccmFullPath} does not exist. Skipping...")
+            if not waccmFilename:
+                logger.warning(f"No file found for date-time {when}. Skipping...")
                 when += datetime.timedelta(hours=strideHours)
                 continue
 
             # read and glean chemical species from WACCM and MUSICA
-            waccmChems = getWaccmSpecies(modelDirs[0], waccmFilename)
+            waccmChems = getWaccmSpecies(waccmFilename)
             musicaChems = getMusicaSpecies(templateFile)
 
             # create map of species common to both WACCM and MUSICA
@@ -753,7 +737,7 @@ def main():
             # Read named variables from WACCM model output.
             logger.info(f"Retrieve WACCM conditions at ({lats} North, {lons} East)   when {when}.")
             waccmValues = readWACCM(commonDict, lats, lons, alts,
-                                    when, modelDirs[0], waccmFilename, modelType)
+                                    when, waccmFilename, modelType)
             logger.debug(f"Original WACCM waccmValues = {waccmValues}")
             varValues.update(waccmValues)
 
@@ -777,6 +761,11 @@ def main():
 
         logger.info(f"Final frameCount = {frameCount}")
         logger.debug(f"Final WACCM accumValues = {accumValues}")
+
+        if not accumValues:
+            logger.error("No time steps found and no values extracted."
+                + "\nPlease check your date-time window against your model output.")
+            sys.exit(1)
 
         # loop through the requested output files/formats
         for output in myArgs.output:

--- a/python/acom_music_box/tools/waccmToMusicBox.py
+++ b/python/acom_music_box/tools/waccmToMusicBox.py
@@ -253,13 +253,13 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
     # as most of the entries are identical. We may map additional
     # pairs in the future. This map is still useful in identifying
     # the common species between WACCM and MUSICA.
-    if (modelType == WACCM_OUT):
+    if (modelType == fileUtils.WACCM_File):
         varMap = {
             # WACCM: MusicBox
             "T": "temperature",
             "lev": "pressure"       # sigma pressure coordinates
         }
-    elif (modelType == WRFCHEM_OUT):
+    elif (modelType == fileUtils.WRF_Chem_file):
         varMap = {
             # WRF-Chem: MusicBox
             "T2": "temperature",
@@ -280,7 +280,7 @@ def getMusicaDictionary(modelType, waccmSpecies=None, musicaSpecies=None):
 # when = date and time to extract
 # modelDir = directory containing model output
 # waccmFilename = name of the model output file
-# modelType = WACCM_OUT or WRFCHEM_OUT
+# modelType = WACCM_File or WRF)Chem_File
 # return dictionary of MUSICA variable names, units, and values
 def readWACCM(waccmMusicaDict, latitudes, longitudes, altitudes,
               when, modelDir, waccmFilename, modelType):
@@ -295,11 +295,11 @@ def readWACCM(waccmMusicaDict, latitudes, longitudes, altitudes,
 
     # retrieve all vars at a single point
     meanPoint = None
-    if (modelType == WACCM_OUT):            # straight grid
+    if (modelType == fileUtils.WACCM_File):            # straight grid
         meanPoint = gridUtils.meanStraightGrid(waccmDataSet, when,
                                                latitudes, longitudes, altitudes)
 
-    elif (modelType == WRFCHEM_OUT):        # curved grid
+    elif (modelType == fileUtils.WRF_Chem_File):        # curved grid
         wrfDataSet = netCDF4.Dataset(waccmFilepath)     # needed for the z-levels
         meanPoint = gridUtils.meanCurvedGrid(waccmDataSet, when,
                                              latitudes, longitudes, altitudes,
@@ -576,12 +576,6 @@ def appendRow(waccmData, moreData):
     return waccmData
 
 
-# type of model output in directory
-WACCM_OUT = 1
-WRFCHEM_OUT = 2
-modelNames = [None, "waccm", "wrf-chem"]
-
-
 # Main routine begins here.
 def main():
     # start with basic logging until args are parsed
@@ -668,14 +662,29 @@ def main():
     # write the requested (calculated) output
     insertIntoConfig = False
 
-    for modelDir, modelType, modelStride in zip(
-            [waccmDir, wrfChemDir], [WACCM_OUT, WRFCHEM_OUT], [6, 1]):
-        if (len(modelDir) == 0):
+    # process the two model types
+    for modelDirs, modelType, modelStride in zip(
+            [waccmDir, wrfChemDir],
+            [fileUtils.WACCM_File, fileUtils.WRF_Chem_File],
+            [6, 1]):
+        if (len(modelDirs) == 0):
             continue
 
-        logger.info(f"Directories: {modelDir}   type {modelType}")
-        files = fileUtils.collectFilesDates(modelDir)
-        logger.info(f"Collected files: {files}")
+        # collect model output files in specified directories
+        logger.info(f"Directories: {modelDirs}   type {modelType}")
+        allFiles = []
+        for modelDir in modelDirs:
+            outFiles = fileUtils.collectFilesDates(modelDir, modelType)
+            allFiles.extend(outFiles)
+
+        # sort the output files by date-time
+        fileUtils.sortFiles(allFiles)
+        logger.info(f"Collected files (sorted):")
+        for outFile in allFiles:
+            outFile.display()
+
+        # possibly exit here if just collecting files
+        #sys.exit(0)    # bogus
 
         # determine the date-time bounds to retrieve
         startDateTime = datetime.datetime.strptime(
@@ -701,29 +710,29 @@ def main():
             seconds = (when - startDateTime).total_seconds()
 
             # locate the WACCM output file
-            if (modelType == WACCM_OUT):
+            if (modelType == fileUtils.WACCM_File):
                 waccmFilename = f"f.e22.beta02.FWSD.f09_f09_mg17.cesm2_2_beta02.forecast.001.cam.h3.{when.year:4d}-{when.month:02d}-{when.day:02d}-00000.nc"
-            elif (modelType == WRFCHEM_OUT):
+            elif (modelType == fileUtils.WRF_Chem_File):
                 waccmFilename = f"wrfout_hourly_d01_{when.year:4d}-{when.month:02d}-{when.day:02d}_{when.hour:02d}:00:00"
 
             # Windows does not allow colons : in filenames. Replace with hyphen -.
             if not pathvalidate.is_valid_filename(waccmFilename, platform="auto"):
                 waccmFilename = waccmFilename.replace(":", "-")
 
-            if (modelType == WRFCHEM_OUT):
+            if (modelType == fileUtils.WRF_Chem_File):
                 # WRF-Chem convention stores files in sub-directories by date
                 dateDir = f"{when.year:4d}{when.month:02d}{when.day:02d}"
                 waccmFilename = os.path.join(dateDir, "wrf", waccmFilename)
 
             # if this frame time is not present, skip
-            waccmFullPath = os.path.join(modelDir[0], waccmFilename)
+            waccmFullPath = os.path.join(modelDirs[0], waccmFilename)
             if not os.path.exists(waccmFullPath):
                 logger.warning(f"File {waccmFullPath} does not exist. Skipping...")
                 when += datetime.timedelta(hours=strideHours)
                 continue
 
             # read and glean chemical species from WACCM and MUSICA
-            waccmChems = getWaccmSpecies(modelDir[0], waccmFilename)
+            waccmChems = getWaccmSpecies(modelDirs[0], waccmFilename)
             musicaChems = getMusicaSpecies(templateFile)
 
             # create map of species common to both WACCM and MUSICA
@@ -739,7 +748,7 @@ def main():
             # Read named variables from WACCM model output.
             logger.info(f"Retrieve WACCM conditions at ({lats} North, {lons} East)   when {when}.")
             waccmValues = readWACCM(commonDict, lats, lons, alts,
-                                    when, modelDir[0], waccmFilename, modelType)
+                                    when, modelDirs[0], waccmFilename, modelType)
             logger.debug(f"Original WACCM waccmValues = {waccmValues}")
             varValues.update(waccmValues)
 

--- a/python/tests/integration/test_waccm_conversion.py
+++ b/python/tests/integration/test_waccm_conversion.py
@@ -60,8 +60,9 @@ def test_waccm_to_music_box_conversion(temp_dir):
     jsonOutPath = os.path.join("wrfchemExtract", "initial_conditions-wrfchem.json")
 
     # Set up arguments for the WRF-Chem conversion
+    wrf_chem_dir = os.path.join(sample_data_dir, "20250820", "wrf")
     args = [
-        "--wrfchemDir", f"{sample_data_dir}",
+        "--wrfchemDir", f"{wrf_chem_dir}",
         "--date", "20250820",
         "--time", "08:00",
         "--latitude", "47.0,49.0",


### PR DESCRIPTION
Instead of trying to predict the filenames of WACCM and WRF-Chem model output, we scan one or more directories for NetCDF files. Then we extract variables values for initial and evolving conditions based on the date-time step that the NetCDF files contain.