### PR TITLE
Fix PhaseSpecies calls for current musica (pass name= kwarg)

### DIFF
--- a/python/tests/integration/test_export_round_trip.py
+++ b/python/tests/integration/test_export_round_trip.py
@@ -50,7 +50,7 @@ def _build_model():
     gas = mc.Phase(
         name="gas",
         species=[
-            mc.PhaseSpecies(srf.name, diffusion_coefficient_m2_s=1e-5),
+            mc.PhaseSpecies(name=srf.name, diffusion_coefficient_m2_s=1e-5),
             A, B, C, D, E, F, G, H, I, J,
         ],
     )

--- a/python/tests/integration/test_surface.py
+++ b/python/tests/integration/test_surface.py
@@ -9,7 +9,7 @@ def in_code_surface_reaction():
     A = mc.Species(name="A", molecular_weight_kg_mol=6)
     B = mc.Species(name="B")
     species = {s.name: s for s in [A, B]}
-    gas = mc.Phase(name="gas", species=[mc.PhaseSpecies(A.name, diffusion_coefficient_m2_s=1e-9), B])
+    gas = mc.Phase(name="gas", species=[mc.PhaseSpecies(name=A.name, diffusion_coefficient_m2_s=1e-9), B])
     surface = mc.Surface(name="surface", reaction_probability=1.0, gas_phase_species=A, gas_phase_products=[B], gas_phase=gas)
     mechanism = mc.Mechanism(name="test_mechanism", species=list(species.values()), phases=[gas], reactions=[surface])
     box_model = MusicBox()


### PR DESCRIPTION
## Problem

Every Python `build` job is failing on `main` (and therefore on all open PRs) with:

```
AttributeError: 'str' object has no attribute 'name'
  .../musica/mechanism_configuration/species/phase_species.py:51
```

in `test_surface.py::test_box_model[in_code_surface_reaction]` and
`test_export_round_trip.py` (2 tests).

## Cause

musica's `PhaseSpecies.__init__` signature is `(species=None, name=None, ...)` — the
**first positional argument is `species`** (a `Species` object). Two integration tests
pass a species *name* (a `str`) positionally:

```python
mc.PhaseSpecies(A.name, diffusion_coefficient_m2_s=1e-9)
```

so the string is bound to `species`, and `self.name = ... species.name` throws. This
breaks against current musica (0.16.2+); it's independent of any feature work.

## Fix

Pass the name explicitly as a keyword: `mc.PhaseSpecies(name=A.name, ...)`. Two lines.
Verified: the two integration test files pass locally, and `name=` is accepted by both
older (0.16.0) and current musica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)