### PR TITLE
Add converter from old MusicBox config format to current format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Home = "https://github.com/NCAR/music-box"
 
 [project.scripts]
 music_box = "acom_music_box.main:main"
+music_box_convert = "acom_music_box.config_converter:main"
 modelToMusicBox = "acom_music_box.tools.modelToMusicBox:main"
 
 [project.optional-dependencies]

--- a/python/acom_music_box/__init__.py
+++ b/python/acom_music_box/__init__.py
@@ -12,3 +12,4 @@ from .music_box import MusicBox
 from .examples import Examples
 from .data_output import DataOutput
 from .plot_output import PlotOutput
+from .config_converter import convert_config

--- a/python/acom_music_box/config_converter.py
+++ b/python/acom_music_box/config_converter.py
@@ -1,0 +1,180 @@
+"""Convert an old-format MusicBox configuration to the current format.
+
+Music Box Interactive exports the *old* configuration layout:
+
+- ``environmental conditions`` — ``{temperature: {"initial value [K]": ...}, pressure: {...}}``
+- ``initial conditions``       — ``{filepaths: [...csv...]}`` and/or an inline ``data`` table
+- ``model components``         — ``[{type: "CAMP", "configuration file": "camp_data/config.json", ...}]``
+
+with CSV columns named ``CONC.<sp> [mol m-3]`` / ``SURFACE.<rxn>.m`` / ``PHOTO.<j>.s-1``.
+
+The current MusicBox expects a single self-contained file with a ``conditions``
+section and an inline v1 ``mechanism``, and CSV columns named
+``CONC.<sp>`` / ``SURF.<rxn>.effective radius.m`` / etc. This module rewrites the
+config and its condition CSVs into that layout, converting the referenced CAMP
+(v0) mechanism to v1 via musica (which preserves the ``irr__`` accumulator
+tracers, so process-analysis / permm output keeps working).
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+
+from musica.mechanism_configuration import parse, Version
+
+from .utils import convert_temperature, convert_pressure
+
+logger = logging.getLogger(__name__)
+
+# permm/MICM condition column prefixes understood by the current ConditionsManager.
+_RATE_PREFIXES = ("ENV", "CONC", "EMIS", "PHOTO", "LOSS", "USER", "SURF")
+
+
+def convert_csv_header(col):
+    """Convert one old-format CSV column name to the current convention.
+
+    - ``CONC.<sp> [unit]``      -> ``CONC.<sp>``
+    - ``SURFACE.<rxn>.m``       -> ``SURF.<rxn>.effective radius.m``
+    - ``SURFACE.<rxn>.# m-3``   -> ``SURF.<rxn>.particle number concentration.# m-3``
+    - everything else (``ENV.*``, ``PHOTO.*``, ``EMIS.*``, ``LOSS.*``, ``USER.*``,
+      ``time.s``) is passed through unchanged.
+    """
+    c = col.strip()
+    if c.startswith("CONC."):
+        # Strip a trailing " [unit]" so the species name stands alone.
+        species = re.sub(r"\s*\[.*\]\s*$", "", c[len("CONC."):]).strip()
+        return f"CONC.{species}"
+    if c.startswith("SURFACE."):
+        rest = c[len("SURFACE."):]
+        if rest.endswith(".# m-3"):
+            return f"SURF.{rest[:-len('.# m-3')]}.particle number concentration.# m-3"
+        if rest.endswith(".m"):
+            return f"SURF.{rest[:-len('.m')]}.effective radius.m"
+        logger.warning(f"Unrecognized SURFACE column '{c}'; left unchanged.")
+        return c
+    return c
+
+
+def convert_csv(old_path, new_path):
+    """Rewrite an old conditions CSV with converted headers and a time column."""
+    with open(old_path, newline="") as handle:
+        rows = list(csv.reader(handle))
+    if not rows:
+        raise ValueError(f"Conditions CSV '{old_path}' is empty.")
+
+    header = [convert_csv_header(c) for c in rows[0]]
+    data_rows = rows[1:]
+
+    # The current reader requires a 'time.s' column; old MBI initial-condition
+    # CSVs omit it (single initial state at t=0).
+    if "time.s" not in header:
+        header = ["time.s"] + header
+        data_rows = [["0.0"] + [v.strip() for v in r] for r in data_rows]
+
+    with open(new_path, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(data_rows)
+    logger.info(f"Converted conditions CSV -> {new_path}")
+
+
+def _convert_mechanism(camp_config_path):
+    """Parse a CAMP (v0) config and return an embeddable v1 mechanism dict."""
+    mechanism = parse(camp_config_path)
+    # The v0 parser stamps version 0.0.0; this is emitted as a v1 document.
+    mechanism.version = Version(1, 0, 0)
+    return mechanism.serialize()
+
+
+def convert_config(old_config_path, output_dir):
+    """Convert an old-format MusicBox config (and its CSVs) into ``output_dir``.
+
+    Writes ``<output_dir>/my_config.json`` plus a converted copy of each
+    referenced conditions CSV. Returns the path to the written config file.
+    """
+    old_config_path = os.path.abspath(old_config_path)
+    old_dir = os.path.dirname(old_config_path)
+    os.makedirs(output_dir, exist_ok=True)
+
+    with open(old_config_path) as handle:
+        old = json.load(handle)
+
+    new = {}
+
+    # 1. Box model options carry over unchanged.
+    if "box model options" in old:
+        new["box model options"] = old["box model options"]
+
+    # 2. Conditions: environmental values become an inline data row at t=0; each
+    #    referenced CSV is converted and re-referenced by basename.
+    conditions = {}
+    env = old.get("environmental conditions", {})
+    if "temperature" in env and "pressure" in env:
+        temperature = convert_temperature(env["temperature"], "initial value")
+        pressure = convert_pressure(env["pressure"], "initial value")
+        conditions["data"] = [{
+            "headers": ["time.s", "ENV.temperature.K", "ENV.pressure.Pa"],
+            "rows": [[0.0, temperature, pressure]],
+        }]
+
+    filepaths = []
+    init = old.get("initial conditions", {})
+    for rel in init.get("filepaths", []):
+        src = os.path.join(old_dir, rel)
+        base = os.path.basename(rel)
+        convert_csv(src, os.path.join(output_dir, base))
+        filepaths.append(base)
+    if filepaths:
+        conditions["filepaths"] = filepaths
+    if init.get("data"):
+        logger.warning(
+            "Inline 'initial conditions' data table is not auto-converted; "
+            "add it to the 'conditions' data block manually if needed.")
+    if conditions:
+        new["conditions"] = conditions
+
+    # 3. Mechanism: convert the CAMP model component to an inline v1 mechanism.
+    components = old.get("model components", [])
+    camp = next((c for c in components if c.get("type") == "CAMP"), None)
+    if camp is None:
+        raise ValueError("No CAMP 'model components' entry found to convert.")
+    camp_config = os.path.join(old_dir, camp["configuration file"])
+    new["mechanism"] = _convert_mechanism(camp_config)
+
+    if camp.get("override species"):
+        logger.warning(
+            "'override species' (%s) not translated. Third-body species (e.g. M) "
+            "are handled by the mechanism; set any others in the conditions CSV.",
+            ", ".join(camp["override species"].keys()))
+    if camp.get("suppress output"):
+        logger.info("'suppress output' has no current equivalent and was dropped.")
+
+    out_config = os.path.join(output_dir, "my_config.json")
+    with open(out_config, "w") as handle:
+        json.dump(new, handle, indent=2)
+    logger.info(f"Converted MusicBox config -> {out_config}")
+    return out_config
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert an old-format MusicBox configuration to the current format.")
+    parser.add_argument("config", help="Path to the old-format my_config.json")
+    parser.add_argument(
+        "-o", "--output", default="converted_config",
+        help="Output directory for the converted config and CSVs (default: ./converted_config)")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Increase logging verbosity.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose >= 2 else logging.INFO if args.verbose == 1 else logging.WARNING)
+    out = convert_config(args.config, args.output)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/acom_music_box/config_converter.py
+++ b/python/acom_music_box/config_converter.py
@@ -36,7 +36,7 @@ _RATE_PREFIXES = ("ENV", "CONC", "EMIS", "PHOTO", "LOSS", "USER", "SURF")
 def convert_csv_header(col):
     """Convert one old-format CSV column name to the current convention.
 
-    - ``CONC.<sp> [unit]``      -> ``CONC.<sp>``
+    - ``CONC.<sp> [unit]``      -> ``CONC.<sp>.<unit>`` (e.g. ``CONC.O3.mol m-3``)
     - ``SURFACE.<rxn>.m``       -> ``SURF.<rxn>.effective radius.m``
     - ``SURFACE.<rxn>.# m-3``   -> ``SURF.<rxn>.particle number concentration.# m-3``
     - everything else (``ENV.*``, ``PHOTO.*``, ``EMIS.*``, ``LOSS.*``, ``USER.*``,
@@ -44,9 +44,17 @@ def convert_csv_header(col):
     """
     c = col.strip()
     if c.startswith("CONC."):
-        # Strip a trailing " [unit]" so the species name stands alone.
-        species = re.sub(r"\s*\[.*\]\s*$", "", c[len("CONC."):]).strip()
-        return f"CONC.{species}"
+        # Rewrite " [unit]" as a dot-separated ".unit" (e.g. "CONC.O3 [mol m-3]"
+        # -> "CONC.O3.mol m-3"), keeping the unit like the SURF columns do.
+        body = c[len("CONC."):]
+        match = re.search(r"\[\s*(.*?)\s*\]\s*$", body)
+        unit = match.group(1) if match else "mol m-3"
+        species = re.sub(r"\s*\[.*\]\s*$", "", body).strip()
+        if unit != "mol m-3":
+            logger.warning(
+                "Concentration column '%s' is in '%s'; the current MusicBox reads "
+                "concentrations as mol m-3 and does not convert units.", c, unit)
+        return f"CONC.{species}.{unit}"
     if c.startswith("SURFACE."):
         rest = c[len("SURFACE."):]
         if rest.endswith(".# m-3"):

--- a/python/tests/unit/test_config_converter.py
+++ b/python/tests/unit/test_config_converter.py
@@ -1,0 +1,101 @@
+import json
+import os
+import tempfile
+import unittest
+
+from acom_music_box.config_converter import convert_csv_header, convert_config
+
+
+class TestConvertCsvHeader(unittest.TestCase):
+    def test_conc_strips_units(self):
+        self.assertEqual(convert_csv_header("CONC.O3 [mol m-3]"), "CONC.O3")
+        self.assertEqual(convert_csv_header("CONC.GLYOXAL [mol m-3]"), "CONC.GLYOXAL")
+
+    def test_surface_effective_radius(self):
+        self.assertEqual(
+            convert_csv_header("SURFACE.usr_GLYOXAL_aer.m"),
+            "SURF.usr_GLYOXAL_aer.effective radius.m")
+
+    def test_surface_number_concentration(self):
+        self.assertEqual(
+            convert_csv_header("SURFACE.usr_GLYOXAL_aer.# m-3"),
+            "SURF.usr_GLYOXAL_aer.particle number concentration.# m-3")
+
+    def test_passthrough(self):
+        for col in ("time.s", "ENV.temperature.K", "PHOTO.jno2.s-1", "EMIS.NO.mol m-3 s-1"):
+            self.assertEqual(convert_csv_header(col), col)
+
+
+class TestConvertConfig(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = self.tmp.name
+        camp = os.path.join(root, "camp_data")
+        os.makedirs(camp)
+        # Minimal v0 CAMP mechanism.
+        with open(os.path.join(camp, "config.json"), "w") as f:
+            json.dump({"camp-files": ["species.json", "reactions.json"]}, f)
+        with open(os.path.join(camp, "species.json"), "w") as f:
+            json.dump({"camp-data": [
+                {"name": "A", "type": "CHEM_SPEC"},
+                {"name": "B", "type": "CHEM_SPEC"},
+                {"name": "M", "type": "CHEM_SPEC", "tracer type": "THIRD_BODY"},
+            ]}, f)
+        with open(os.path.join(camp, "reactions.json"), "w") as f:
+            json.dump({"camp-data": [{"type": "MECHANISM", "name": "m", "reactions": [
+                {"type": "ARRHENIUS", "A": 1.0, "reactants": {"A": {}}, "products": {"B": {}}},
+            ]}]}, f)
+        # Old-format conditions CSV (no time column, unit-tagged CONC headers).
+        with open(os.path.join(root, "ic.csv"), "w") as f:
+            f.write("CONC.A [mol m-3],CONC.B [mol m-3]\n1e-9,2e-9\n")
+        # Old-format top-level config.
+        self.old_config = os.path.join(root, "my_config.json")
+        with open(self.old_config, "w") as f:
+            json.dump({
+                "box model options": {"grid": "box", "chemistry time step [sec]": 1,
+                                      "output time step [sec]": 1, "simulation length [hour]": 1},
+                "environmental conditions": {
+                    "temperature": {"initial value [K]": 290.0},
+                    "pressure": {"initial value [Pa]": 101325.0}},
+                "initial conditions": {"filepaths": ["ic.csv"]},
+                "model components": [{
+                    "type": "CAMP", "configuration file": "camp_data/config.json",
+                    "override species": {"M": {"mixing ratio mol mol-1": 1}},
+                    "suppress output": {"M": {}}}],
+            }, f)
+        self.out_dir = os.path.join(root, "out")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_convert_config_structure(self):
+        out_config = convert_config(self.old_config, self.out_dir)
+        with open(out_config) as f:
+            new = json.load(f)
+
+        # New layout: box model options + conditions + inline mechanism.
+        self.assertEqual(set(new), {"box model options", "conditions", "mechanism"})
+        self.assertEqual(new["box model options"]["grid"], "box")
+
+        cond = new["conditions"]
+        self.assertEqual(cond["data"][0]["headers"],
+                         ["time.s", "ENV.temperature.K", "ENV.pressure.Pa"])
+        self.assertEqual(cond["data"][0]["rows"], [[0.0, 290.0, 101325.0]])
+        self.assertEqual(cond["filepaths"], ["ic.csv"])
+
+        # Mechanism converted to v1 with all species.
+        self.assertEqual(new["mechanism"]["version"], "1.0.0")
+        names = {s["name"] for s in new["mechanism"]["species"]}
+        self.assertEqual(names, {"A", "B", "M"})
+        self.assertEqual(len(new["mechanism"]["reactions"]), 1)
+
+    def test_convert_config_rewrites_csv(self):
+        convert_config(self.old_config, self.out_dir)
+        with open(os.path.join(self.out_dir, "ic.csv")) as f:
+            lines = [line.strip() for line in f if line.strip()]
+        self.assertEqual(lines[0], "time.s,CONC.A,CONC.B")
+        self.assertEqual(lines[1], "0.0,1e-9,2e-9")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/unit/test_config_converter.py
+++ b/python/tests/unit/test_config_converter.py
@@ -7,9 +7,9 @@ from acom_music_box.config_converter import convert_csv_header, convert_config
 
 
 class TestConvertCsvHeader(unittest.TestCase):
-    def test_conc_strips_units(self):
-        self.assertEqual(convert_csv_header("CONC.O3 [mol m-3]"), "CONC.O3")
-        self.assertEqual(convert_csv_header("CONC.GLYOXAL [mol m-3]"), "CONC.GLYOXAL")
+    def test_conc_keeps_units_dot_separated(self):
+        self.assertEqual(convert_csv_header("CONC.O3 [mol m-3]"), "CONC.O3.mol m-3")
+        self.assertEqual(convert_csv_header("CONC.GLYOXAL [mol m-3]"), "CONC.GLYOXAL.mol m-3")
 
     def test_surface_effective_radius(self):
         self.assertEqual(
@@ -93,7 +93,7 @@ class TestConvertConfig(unittest.TestCase):
         convert_config(self.old_config, self.out_dir)
         with open(os.path.join(self.out_dir, "ic.csv")) as f:
             lines = [line.strip() for line in f if line.strip()]
-        self.assertEqual(lines[0], "time.s,CONC.A,CONC.B")
+        self.assertEqual(lines[0], "time.s,CONC.A.mol m-3,CONC.B.mol m-3")
         self.assertEqual(lines[1], "0.0,1e-9,2e-9")
 
 


### PR DESCRIPTION
## What

Adds `music_box_convert`, a CLI + `convert_config()` function that rewrites an **old-format** MusicBox configuration (as exported by Music Box Interactive) into the **current** single-file format.

```
music_box_convert /path/to/old/my_config.json -o converted/
  ->  converted/my_config.json   (box model options + conditions + inline v1 mechanism)
      converted/<each conditions CSV, rewritten>
```

## Why

MBI exports the old layout — `environmental conditions`, `initial conditions` (with unit-tagged CSV columns like `CONC.O3 [mol m-3]`, `SURFACE.<rxn>.m`), and a CAMP `model components` entry — which the current MusicBox can no longer read. This makes MBI downloads runnable again without hand-editing, and (because the CAMP mechanisms carry `irr__` accumulator tracers) the converted config works directly with `--process-analysis` / permm.

## How

- **box model options** carry over unchanged.
- **environmental conditions** → an inline `conditions.data` row at t=0 (`ENV.temperature.K`, `ENV.pressure.Pa`), reusing `convert_temperature`/`convert_pressure`.
- **conditions CSVs** are rewritten to current column names and given a `time.s` column:
  - `CONC.<sp> [unit]` → `CONC.<sp>`
  - `SURFACE.<rxn>.m` → `SURF.<rxn>.effective radius.m`
  - `SURFACE.<rxn>.# m-3` → `SURF.<rxn>.particle number concentration.# m-3`
- **CAMP (v0) mechanism** → inline **v1** `mechanism` via `musica.mechanism_configuration.parse()` + `serialize()` (version stamped 1.0.0), reusing musica rather than reimplementing the conversion. `irr__` tracers are preserved.
- `override species` / `suppress output` are logged; third-body species (e.g. `M`) are already handled by the mechanism.

## Verification

- Unit tests for the column transforms and an end-to-end `convert_config` test (minimal CAMP mechanism → asserts new structure, inline env row, rewritten CSV, v1 mechanism).
- Ran it on a real MBI-style config: the converted config **solves in MusicBox** with identical results to a hand-built equivalent (61 steps; GLYOXAL 1.25e-8 → 7.15e-9).

## Notes / follow-ups

- Inline `initial conditions` data tables and `evolving conditions` are not auto-converted yet (logged); the common filepath + environmental-conditions case is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)