### PR TITLE
Require musica>=0.16.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "colorlog>=6.7.0",
   "matplotlib>=3.6.0",
   "mplcursors>=0.3",
-  "musica>=0.16.4",
+  "musica>=0.16.5",
   "netcdf4>=1.6.0",
   "numpy>=2.0.0",
   "pandas>=2.2.0",
@@ -55,7 +55,7 @@ dev = [
   "pytest-cov>=7.0.0"
 ]
 gpu = [
-  "musica[gpu]==0.16.4"
+  "musica[gpu]==0.16.5"
 ]
 doc = [
   "ipython",


### PR DESCRIPTION
Bumps the musica floor (and the gpu extra pin) from 0.16.4 to **0.16.5**.

0.16.5 keeps reactant-less photolysis reactions — emissions that Music Box Interactive encodes as photolysis to carry an `irr__` product — which earlier musica dropped. This is required for MBI configs such as **CB05** to convert and run through the CLI.

Verified: a clean `pip install acom_music_box` now pulls musica 0.16.5, and the CB05 config converts + runs + produces permm output end-to-end (previously failed with `PHOTO.EMIS_NO not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)