### PR TITLE
Name reactant-less permm reactions after the reaction, not "HV"

### DIFF
--- a/python/acom_music_box/process_analysis_output.py
+++ b/python/acom_music_box/process_analysis_output.py
@@ -113,12 +113,15 @@ class ProcessAnalysisOutput:
             arrow = "->[j]" if photolysis else "->[k]"
 
             reactant_names = [c.name for c in reactants]
-            base = "_".join(reactant_names)
-            if photolysis:
-                base = (base + "_HV") if base else "HV"
-            if not base:
-                # Fall back to the reaction's own name (e.g. emissions with no reactants).
-                base = getattr(rxn, "name", "") or type(rxn).__name__
+            if reactant_names:
+                base = "_".join(reactant_names)
+                if photolysis:
+                    base += "_HV"
+            else:
+                # No reactants (e.g. an emission encoded as reactant-less
+                # photolysis): use the reaction's own name so the IRR variable is
+                # identifiable rather than a generic "HV".
+                base = getattr(rxn, "name", "") or ("HV" if photolysis else type(rxn).__name__)
 
             name = self._unique_name(base + IRR_SUFFIX, used_names)
 

--- a/python/tests/unit/test_process_analysis_output.py
+++ b/python/tests/unit/test_process_analysis_output.py
@@ -62,16 +62,19 @@ class TestProcessAnalysisOutput(unittest.TestCase):
             # Same reactants as the first reaction -> exercises name disambiguation.
             Arrhenius([_Comp("NO3"), _Comp("CH3COCHO")],
                       [_Comp("HNO3", 0.5), _Comp("irr__ddd")]),
+            # Reactant-less photolysis (an emission) -> named after the reaction.
+            Photolysis([], [_Comp("NO"), _Comp("irr__eee")], name="EMIS_NO"),
         ]
         self.species = [_Species(n) for n in (
-            "NO3", "CH3COCHO", "HNO3", "CO", "CCL4", "CL", "GLYOXAL", "SOAG0",
-            "irr__aaa", "irr__bbb", "irr__ccc", "irr__ddd")]
+            "NO3", "CH3COCHO", "HNO3", "CO", "CCL4", "CL", "GLYOXAL", "SOAG0", "NO",
+            "irr__aaa", "irr__bbb", "irr__ccc", "irr__ddd", "irr__eee")]
         self.mech = _Mechanism(self.reactions, self.species)
 
         # Three output steps; irr tracers accumulate (cumulative IRR).
         cols = {"time.s": [0.0, 60.0, 120.0]}
         for s in self.species:
-            base = {"irr__aaa": 1e-12, "irr__bbb": 2e-12, "irr__ccc": 3e-12, "irr__ddd": 4e-12}.get(s.name, 0.0)
+            base = {"irr__aaa": 1e-12, "irr__bbb": 2e-12, "irr__ccc": 3e-12,
+                    "irr__ddd": 4e-12, "irr__eee": 5e-12}.get(s.name, 0.0)
             cols[f"CONC.{s.name}.mol m-3"] = [base, base * 2, base * 3]
         self.df = pd.DataFrame(cols)
 
@@ -94,15 +97,17 @@ class TestProcessAnalysisOutput(unittest.TestCase):
         # Real species only; tracers excluded.
         self.assertNotIn("irr__aaa", doc["species_list"])
         self.assertIn("GLYOXAL", doc["species_list"])
-        self.assertEqual(len(doc["species_list"]), 8)
+        self.assertEqual(len(doc["species_list"]), 9)
 
         rl = doc["reaction_list"]
-        self.assertEqual(len(rl), 4)
+        self.assertEqual(len(rl), 5)
         # Names, disambiguation, and grammar.
         self.assertEqual(rl["NO3_CH3COCHO_IRR"], "NO3 + CH3COCHO ->[k] HNO3 + CO")
         self.assertEqual(rl["CCL4_HV_IRR"], "CCL4 ->[j] 4*CL")
         self.assertEqual(rl["GLYOXAL_IRR"], "GLYOXAL ->[k] SOAG0")
         self.assertEqual(rl["NO3_CH3COCHO_a_IRR"], "NO3 + CH3COCHO ->[k] 0.5*HNO3")
+        # A reactant-less photolysis (emission) is named after the reaction, not "HV".
+        self.assertEqual(rl["EMIS_NO_IRR"], "->[j] NO")
         # No irr__ tracer leaks into any equation.
         self.assertFalse(any("irr__" in eq for eq in rl.values()))
 


### PR DESCRIPTION
## Problem

Now that reactant-less photolysis reactions are kept (musica 0.16.5), the process-analysis writer named every one of them `HV_IRR`, `HV_a_IRR`, `HV_b_IRR`, … because it builds the reaction/IRR-variable name from the reactants — and these have none. In CB05 that's 14 emissions (`EMIS_NO`, `EMIS_IOLE`, …) all collapsed to indistinguishable `HV_*` names.

## Fix

When a reaction has no reactants, use its own name as the base, so the IRR variables are identifiable: `EMIS_NO_IRR`, `EMIS_IOLE_IRR`, etc. Reactions with reactants are unchanged (`O3_HV_IRR`, `NO_HO2_IRR`, …).

Verified on CB05: 14 `EMIS_*_IRR` variables, zero generic `HV_*`. Adds a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)