### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/python/acom_music_box/__init__.py
+++ b/python/acom_music_box/__init__.py
@@ -4,7 +4,7 @@ An atmospheric chemistry box model. Powered by MUSICA.
 This package contains modules for handling various aspects of a music box,
 including species, products, reactants, reactions, and more.
 """
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 from .utils import convert_time, convert_pressure, convert_temperature, convert_concentration
 from .model_options import BoxModelOptions


### PR DESCRIPTION
Release bump 3.2.0 → **3.3.0** to publish the converter/process-analysis fixes since 3.2.0:

- **#493** — config converter handles `evolving conditions`, inline `data` tables, and ENV-unit columns. This is what makes **Chapman** work: it keeps all its photolysis rates in `evolving_conditions.csv`, which 3.2.0's converter dropped (the run then had no photolysis and O3 stayed flat).
- **#494** — require `musica>=0.16.5`, which keeps reactant-less photolysis (emissions), so **CB05** converts and runs.
- **#495** — process-analysis names reactant-less reactions after the reaction (`EMIS_NO_IRR`) instead of a generic `HV_IRR`.

Minor bump: backward-compatible new converter capability plus a raised musica floor. After merge + publish, `pip install acom_music_box` gives all MBI configs a working convert → run → permm-output path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)